### PR TITLE
feat(admin): Rename User to Customer in admin/super-admin panel

### DIFF
--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -28,7 +28,7 @@ const navItems: NavItem[] = [
   { id: 'dashboard', path: 'dashboard', icon: LayoutDashboard, label: 'Dashboard' },
   { id: 'vehicles', path: 'vehicles', icon: Bike, label: 'Vehicles' },
   { id: 'bookings', path: 'bookings', icon: Calendar, label: 'Bookings' },
-  { id: 'users', path: 'users', icon: Users, label: 'Users' },
+  { id: 'users', path: 'users', icon: Users, label: 'Customers' },
   { id: 'staff', path: 'staff', icon: UserCog, label: 'Staff' },
   { id: 'promo-codes', path: 'promo-codes', icon: Tag, label: 'Promo Codes' },
   { id: 'pickup-points', path: 'pickup-points', icon: MapPin, label: 'Pickup Points' },

--- a/src/components/admin/BookingsTab.tsx
+++ b/src/components/admin/BookingsTab.tsx
@@ -73,7 +73,7 @@ const BookingsTab: React.FC = () => {
                 {[
                   { label: 'Booking ID',  col: 'id'                       },
                   { label: 'Vehicle ID',  col: 'vehicleId'                },
-                  { label: 'User ID',     col: 'userId'                   },
+                  { label: 'Customer ID',     col: 'userId'                   },
                   { label: 'F&F Contact', col: 'friendFamilyContactNumber'},
                   { label: 'Start Date',  col: 'bookingStartDate'         },
                   { label: 'Amount',      col: 'totalAmount'              },
@@ -95,7 +95,7 @@ const BookingsTab: React.FC = () => {
                 <tr key={booking.id} className="hover:bg-gray-50 transition">
                   <td className="px-6 py-4 font-medium text-gray-900">#{booking.id}</td>
                   <td className="px-6 py-4 text-sm text-gray-600">Vehicle #{booking.vehicleId}</td>
-                  <td className="px-6 py-4 text-sm text-gray-600">User #{booking.userId}</td>
+                  <td className="px-6 py-4 text-sm text-gray-600">Customer #{booking.userId}</td>
                   <td className="px-6 py-4 text-sm text-gray-600">
                     {booking.friendFamilyContactNumber || <span className="text-gray-400">—</span>}
                   </td>

--- a/src/components/admin/OfflineBookingForm.tsx
+++ b/src/components/admin/OfflineBookingForm.tsx
@@ -599,7 +599,7 @@ const OfflineBookingForm: React.FC = () => {
         </div>
         <h2 className="text-2xl font-bold text-gray-900 mb-2">Booking Recorded!</h2>
         <p className="text-gray-600 mb-1">Booking ID: <span className="font-semibold text-primary-600">#{successData.bookingId}</span></p>
-        <p className="text-gray-600 mb-6">User ID: <span className="font-semibold">{successData.userId}</span></p>
+        <p className="text-gray-600 mb-6">Customer ID: <span className="font-semibold">{successData.userId}</span></p>
         <button
           onClick={handleReset}
           className="bg-primary-600 hover:bg-primary-700 text-white px-6 py-2 rounded-lg font-semibold transition"

--- a/src/components/admin/UsersTab.tsx
+++ b/src/components/admin/UsersTab.tsx
@@ -17,12 +17,12 @@ const UsersTab: React.FC = () => {
 
   // ── Handlers ──────────────────────────────────────────────────────────
   const handleDeleteUser = async (id: number) => {
-    if (!confirm('Are you sure you want to delete this user?')) return;
+    if (!confirm('Are you sure you want to delete this customer?')) return;
     try {
       await deleteUser(id).unwrap();
-      toast.success('User deleted');
+      toast.success('Customer deleted');
       refetchUsers();
-    } catch { toast.error('Failed to delete user'); }
+    } catch { toast.error('Failed to delete customer'); }
   };
 
   // ── Filtered Data ──────────────────────────────────────────────────────
@@ -32,7 +32,7 @@ const UsersTab: React.FC = () => {
 
   return (
     <div>
-      <h1 className="text-3xl font-bold text-gray-900 mb-6">User Management</h1>
+      <h1 className="text-3xl font-bold text-gray-900 mb-6">Customer Management</h1>
       <div className="flex gap-4 mb-6">
         <div className="flex-1 relative">
           <Search className="w-5 h-5 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
@@ -50,7 +50,7 @@ const UsersTab: React.FC = () => {
           <table className="w-full">
             <thead className="bg-gray-50">
               <tr>
-                {['User ID', 'Phone Number', 'City ID', 'Actions'].map((h) => (
+                {['Customer ID', 'Phone Number', 'City ID', 'Actions'].map((h) => (
                   <th key={h} className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase">{h}</th>
                 ))}
               </tr>
@@ -76,7 +76,7 @@ const UsersTab: React.FC = () => {
                 </tr>
               ))}
               {filteredUsers.length === 0 && (
-                <tr><td colSpan={4} className="px-6 py-12 text-center text-gray-500">No users found</td></tr>
+                <tr><td colSpan={4} className="px-6 py-12 text-center text-gray-500">No customers found</td></tr>
               )}
             </tbody>
           </table>

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -53,7 +53,7 @@ const AdminDashboard: React.FC = () => {
         {[
           { label: 'Total Vehicles', value: stats.totalVehicles, sub: `${stats.availableVehicles} available`, icon: Bike, color: 'text-primary-600' },
           { label: 'Active Bookings', value: stats.activeBookings, sub: `${stats.pendingBookings} pending`, icon: Calendar, color: 'text-green-600' },
-          { label: 'Total Users', value: stats.totalUsers, sub: 'registered', icon: Users, color: 'text-purple-600' },
+          { label: 'Total Customers', value: stats.totalUsers, sub: 'registered', icon: Users, color: 'text-purple-600' },
           { label: 'Revenue (Confirmed)', value: `₹${stats.monthlyRevenue.toLocaleString()}`, sub: 'total', icon: TrendingUp, color: 'text-orange-600' },
         ].map(({ label, value, sub, icon: Icon, color }) => (
           <div key={label} className="bg-white rounded-xl shadow-md p-6">
@@ -80,7 +80,7 @@ const AdminDashboard: React.FC = () => {
                   <div key={booking.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                     <div>
                       <p className="font-medium text-gray-900">Booking #{booking.id}</p>
-                      <p className="text-sm text-gray-600">User #{booking.userId}</p>
+                      <p className="text-sm text-gray-600">Customer #{booking.userId}</p>
                     </div>
                     <div className="text-right">
                       <p className="font-semibold text-primary-600">₹{booking.totalAmount}</p>

--- a/src/pages/SuperAdminDashboard.tsx
+++ b/src/pages/SuperAdminDashboard.tsx
@@ -25,7 +25,7 @@ type Tab =
 const TAB_CONFIG: { id: Tab; label: string; icon: React.ElementType }[] = [
   { id: 'overview', label: 'Overview', icon: LayoutDashboard },
   { id: 'admins', label: 'Admins', icon: UserCog },
-  { id: 'users', label: 'Users', icon: Users },
+  { id: 'users', label: 'Customers', icon: Users },
   { id: 'bookings', label: 'Bookings', icon: LayoutDashboard },
   { id: 'vehicles', label: 'Vehicles', icon: LayoutDashboard },
   { id: 'pickup-points', label: 'Pickup Points', icon: MapPin },
@@ -171,7 +171,7 @@ const SuperAdminOverview: React.FC = () => (
     <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
       {[
         { label: 'Total Admins', value: '—', color: 'bg-purple-50 text-purple-700' },
-        { label: 'Total Users', value: '—', color: 'bg-blue-50 text-blue-700' },
+        { label: 'Total Customers', value: '—', color: 'bg-blue-50 text-blue-700' },
         { label: 'Total Bookings', value: '—', color: 'bg-green-50 text-green-700' },
         { label: 'Active Promos', value: '—', color: 'bg-orange-50 text-orange-700' },
       ].map(({ label, value, color }) => (

--- a/src/pages/admin/PromoCodesPage.tsx
+++ b/src/pages/admin/PromoCodesPage.tsx
@@ -372,7 +372,7 @@ const PromoCodesPage: React.FC = () => {
                   type="text"
                   value={form.description ?? ''}
                   onChange={(e) => setForm({ ...form, description: e.target.value })}
-                  placeholder="e.g. 20% off for new users"
+                  placeholder="e.g. 20% off for new customers"
                   className="w-full px-4 py-2.5 border border-gray-300 rounded-xl text-sm focus:ring-2 focus:ring-purple-400 focus:border-transparent outline-none transition"
                 />
               </div>
@@ -520,7 +520,7 @@ const PromoCodesPage: React.FC = () => {
                     <div className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${form.isActive ? 'translate-x-5' : 'translate-x-0'}`} />
                   </div>
                   <span className="text-sm text-gray-700">
-                    {form.isActive ? 'Active — users can apply this code' : 'Inactive — code is disabled'}
+                    {form.isActive ? 'Active — customers can apply this code' : 'Inactive — code is disabled'}
                   </span>
                 </label>
                 <label className="flex items-center gap-3 cursor-pointer">


### PR DESCRIPTION
## Summary

Updated visible admin and super-admin panel terminology by replacing **User** with **Customer** for clearer business-facing language.

## Changes Included

* Sidebar/navigation labels updated (`Users` → `Customers`)
* Page headings updated (`User Management` → `Customer Management`)
* Dashboard stats updated (`Total Users` → `Total Customers`)
* Table headers updated (`User ID` → `Customer ID`)
* Booking references updated (`User #123` → `Customer #123`)
* Alerts, placeholders, empty states, and action text updated
* Promo code helper text updated where relevant
* Consistent terminology applied across admin and super-admin panels

## No Functional Changes

This PR only updates display text. No changes were made to:

* API endpoints
* Route paths
* Variable names
* Database fields
* Types/interfaces
* Internal auth roles (`user`)

## Result

Admin and super-admin interfaces now consistently use **Customer** terminology.
