### PR TITLE
feat(staff/admin): widen staff booking window, fix agent date drift, round package prices

### DIFF
--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -38,8 +38,8 @@ type NavItem = {
 }
 
 const navItems: NavItem[] = [
-  { id: 'agent-management', path: 'agent-management', icon: Handshake, label: 'Agent Management' },
   { id: 'dashboard', path: 'dashboard', icon: LayoutDashboard, label: 'Dashboard' },
+  { id: 'agent-management', path: 'agent-management', icon: Handshake, label: 'Agent Management' },
   { id: 'vehicles', path: 'vehicles', icon: Bike, label: 'Vehicles' },
   { id: 'vehicle-packages', path: 'vehicle-packages', icon: Package, label: 'Packages' },
   { id: 'bookings', path: 'bookings', icon: Calendar, label: 'Bookings' },

--- a/src/components/DateTimePicker.tsx
+++ b/src/components/DateTimePicker.tsx
@@ -10,7 +10,6 @@ import { toast } from 'sonner';
 
 const MIN_TIME = '06:00'; // 6 AM
 const MAX_TIME = '23:30'; // 11:30 PM
-const RETURN_DEFAULT_TIME = '23:30'; // returns default to 11:30 PM
 
 // 30-min slots between 6:00 AM and 11:30 PM
 const TIME_SLOTS: string[] = (() => {
@@ -98,7 +97,8 @@ const computeDefaults = () => {
     pickupDate: ymd(pickupDateObj),
     pickupTime,
     returnDate: ymd(returnDateObj),
-    returnTime: RETURN_DEFAULT_TIME,
+    // Default to a 24-hour cycle: same time as pickup, next day
+    returnTime: pickupTime,
   };
 };
 

--- a/src/components/admin/AgentFormModal.tsx
+++ b/src/components/admin/AgentFormModal.tsx
@@ -53,12 +53,28 @@ const buildCode = (name: string, discountValue: string): string => {
 
 const toDateInput = (iso?: string | null): string => {
   if (!iso) return '';
+  // Treat the value as a pure calendar date: take the leading yyyy-MM-dd
+  // verbatim so no timezone conversion can shift it by a day.
+  const datePart = iso.slice(0, 10);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(datePart)) return datePart;
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return '';
   return d.toISOString().slice(0, 10);
 };
 
-const todayInput = () => new Date().toISOString().slice(0, 10);
+// Local "today" as yyyy-MM-dd (matches what the user sees, no UTC drift).
+const todayInput = () => {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+};
+
+// Convert a yyyy-MM-dd date input into an ISO timestamp anchored at noon UTC.
+// Noon UTC keeps the same calendar date in every timezone (-12..+14), so the
+// date can never drift by a day on round-trips through the backend.
+const dateToIso = (ymd: string): string => `${ymd}T12:00:00.000Z`;
 
 export default function AgentFormModal({ agent, initialDraft, onClose, onSaveDraft, onSuccess }: Props) {
   const isEdit = !!agent;
@@ -169,8 +185,8 @@ export default function AgentFormModal({ agent, initialDraft, onClose, onSaveDra
           ? parseFloat(form.maxDiscountAmount)
           : null,
       minOrderAmount: parseFloat(form.minOrderAmount) || 0,
-      validFrom: new Date(form.validFrom).toISOString(),
-      validUntil: form.validUntil ? new Date(form.validUntil).toISOString() : null,
+      validFrom: dateToIso(form.validFrom),
+      validUntil: form.validUntil ? dateToIso(form.validUntil) : null,
       commissionType: form.commissionType,
       commissionValue: commissionValueNum,
       isActive: form.isActive,

--- a/src/pages/BookNow.tsx
+++ b/src/pages/BookNow.tsx
@@ -156,7 +156,8 @@ export default function BookNow() {
     return `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}-${d.getDate().toString().padStart(2, '0')}`;
   };
   const defaultEndDate = isEndDateValid ? endDateParam : getNextDay(defaultStartDate);
-  const defaultEndTime = endTimeParam && isEndDateValid ? roundToNext30Min(clampToBusinessHours(endTimeParam)) : MAX_BUSINESS_TIME;
+  // Default to a 24-hour cycle: same time as pickup, next day
+  const defaultEndTime = endTimeParam && isEndDateValid ? roundToNext30Min(clampToBusinessHours(endTimeParam)) : defaultStartTime;
 
   const [bookingDates, setBookingDates] = useState({
     startDate: defaultStartDate,
@@ -190,13 +191,13 @@ export default function BookNow() {
     const today = getTodayDate();
     const defaultPickup = getDefaultPickupDateTime();
     
-    // If start date is in the past, reset to valid defaults
+    // If start date is in the past, reset to valid defaults (24-hour cycle)
     if (bookingDates.startDate < today) {
       setBookingDates({
         startDate: defaultPickup.date,
         startTime: defaultPickup.time,
-        endDate: defaultPickup.date,
-        endTime: MAX_BUSINESS_TIME,
+        endDate: getNextDay(defaultPickup.date),
+        endTime: defaultPickup.time,
       });
       toast.info('Booking dates have been updated to today');
     }
@@ -204,13 +205,13 @@ export default function BookNow() {
     else if (bookingDates.startDate === today && bookingDates.startTime) {
       const minTime = getMinTimeForToday();
       
-      // If today is no longer bookable (too late), push to tomorrow
+      // If today is no longer bookable (too late), push to tomorrow (24-hour cycle)
       if (minTime === null) {
         setBookingDates({
           startDate: defaultPickup.date,
           startTime: defaultPickup.time,
-          endDate: defaultPickup.date,
-          endTime: MAX_BUSINESS_TIME,
+          endDate: getNextDay(defaultPickup.date),
+          endTime: defaultPickup.time,
         });
         toast.info('Booking dates have been updated - too late to book for today');
       }
@@ -409,7 +410,7 @@ export default function BookNow() {
 
     // Use linkedPackage pricing if available
     const pricePerHour = vehicleData.linkedPackage?.pricePerHour || vehicleData.pricePerHour;
-    const freeHoursPerDay = vehicleData.linkedPackage?.freeHoursPerDay || 6;
+    const freeHoursPerDay = vehicleData.linkedPackage?.freeHoursPerDay ?? 6;
 
     return calculateDurationPrice(hours, pricePerHour, freeHoursPerDay);
   };

--- a/src/pages/VehicleListingPage.tsx
+++ b/src/pages/VehicleListingPage.tsx
@@ -119,7 +119,8 @@ const VehicleListingPage: React.FC = () => {
   const startDate = startDateParam || defaultPickup.date;
   const startTime = startTimeParam || defaultPickup.time;
   const endDate = endDateParam || defaultReturn;
-  const endTime = endTimeParam || MAX_TIME;
+  // Default to a 24-hour cycle: same time as pickup, next day
+  const endTime = endTimeParam || defaultPickup.time;
   const hasDateFilter = true; // Always have dates now (either from URL or defaults)
 
   // Date editing state

--- a/src/pages/admin/VehiclePackagesPage.tsx
+++ b/src/pages/admin/VehiclePackagesPage.tsx
@@ -188,7 +188,7 @@ const VehiclePackagesPage: React.FC = () => {
     setForm({
       name: pkg.name,
       pricePerHour: pkg.pricePerHour,
-      freeHoursPerDay: pkg.freeHoursPerDay || 6,
+      freeHoursPerDay: pkg.freeHoursPerDay ?? 6,
       selectedDurations: [...pkg.selectedDurations],
       priceOverrides: { ...pkg.priceOverrides },
     });

--- a/src/pages/staff/StaffBookingsPage.tsx
+++ b/src/pages/staff/StaffBookingsPage.tsx
@@ -52,17 +52,20 @@ const BookingsList: React.FC = () => {
     const [statusFilter, setStatusFilter] = useState<string>('all');
     const navigate = useNavigate();
 
-    // Staff is restricted to bookings starting within the last 7 days (incl. today).
-    // Compute the window once per render — cheap and stays correct across midnight.
-    const { todayYmd, minYmd } = useMemo(() => {
+    // Staff is restricted to bookings starting within the last 7 days (incl. today)
+    // and the next 7 days. Compute the window once per render — cheap and stays
+    // correct across midnight.
+    const { minYmd, maxYmd } = useMemo(() => {
         const today = new Date();
         const min = new Date();
         min.setDate(today.getDate() - 6); // 6 days ago + today = 7 days
-        return { todayYmd: toYmd(today), minYmd: toYmd(min) };
+        const max = new Date();
+        max.setDate(today.getDate() + 7); // next 7 days
+        return { minYmd: toYmd(min), maxYmd: toYmd(max) };
     }, []);
 
     const [startDate, setStartDate] = useState(minYmd);
-    const [endDate, setEndDate] = useState(todayYmd);
+    const [endDate, setEndDate] = useState(maxYmd);
 
     const { data: bookings = [], isLoading } = useGetStaffBookingsQuery({});
 
@@ -99,8 +102,8 @@ const BookingsList: React.FC = () => {
             <div className="flex items-start gap-2 mb-4 lg:mb-5 px-3 lg:px-4 py-2 lg:py-3 rounded-lg bg-primary-50 border border-primary-100 text-xs lg:text-sm text-primary-700">
                 <Info className="w-4 h-4 mt-0.5 shrink-0" />
                 <span>
-                    Showing bookings from the last 7 days only. Contact an administrator
-                    if you need access to older bookings.
+                    Showing bookings from the last 7 days and the next 7 days only.
+                    Contact an administrator if you need access to older bookings.
                 </span>
             </div>
 
@@ -146,7 +149,7 @@ const BookingsList: React.FC = () => {
                             type="date"
                             value={startDate}
                             min={minYmd}
-                            max={endDate || todayYmd}
+                            max={endDate || maxYmd}
                             onChange={(e) => setStartDate(e.target.value)}
                             className="px-2 lg:px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none text-sm"
                         />
@@ -157,7 +160,7 @@ const BookingsList: React.FC = () => {
                             type="date"
                             value={endDate}
                             min={startDate || minYmd}
-                            max={todayYmd}
+                            max={maxYmd}
                             onChange={(e) => setEndDate(e.target.value)}
                             className="px-2 lg:px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none text-sm"
                         />
@@ -166,7 +169,7 @@ const BookingsList: React.FC = () => {
             </div>
 
             <p className="text-xs text-gray-500 mb-4 lg:mb-6">
-                Date range is restricted to the last 7 days ({minYmd} → {todayYmd}).
+                Date range is restricted to the last 7 days and next 7 days ({minYmd} → {maxYmd}).
             </p>
 
             {/* Bookings Table */}
@@ -523,7 +526,7 @@ const BookingDetail: React.FC<BookingDetailProps> = ({ bookingId, onBack }) => {
                 </div>
                 <h2 className="text-xl font-bold text-gray-900 mb-2">Access Restricted</h2>
                 <p className="text-gray-600 mb-6">
-                    This booking is older than 7 days and cannot be accessed.
+                    This booking is outside the allowed 7-day window and cannot be accessed.
                     Please contact an administrator if you need this information.
                 </p>
                 <button

--- a/src/store/api/vehiclePackageApi.ts
+++ b/src/store/api/vehiclePackageApi.ts
@@ -51,13 +51,15 @@ export const DURATION_OPTIONS = [
 // Calculate price for a given duration (used for package display)
 export function calculateDurationPrice(hours: number, pricePerHour: number, freeHoursPerDay: number = 6): number {
   if (hours < 24) {
-    return hours * pricePerHour;
+    // Round to nearest rupee (>= .50 up, < .50 down) so no float values are shown
+    return Math.round(hours * pricePerHour);
   }
   const days = Math.floor(hours / 24);
   const extraHours = hours % 24;
   // Configurable free hours per day (charge 24 - freeHoursPerDay hours per day)
   const chargeableHoursPerDay = 24 - freeHoursPerDay;
-  return (days * chargeableHoursPerDay + extraHours) * pricePerHour;
+  // Round to nearest rupee (>= .50 up, < .50 down) so no float values are shown
+  return Math.round((days * chargeableHoursPerDay + extraHours) * pricePerHour);
 }
 
 /**
@@ -121,7 +123,8 @@ export function calculatePackageBasedPrice(
 
   // Otherwise, calculate: applicable package price + extra hours × pricePerHour
   const extraHours = bookingHours - applicablePackage.hours;
-  return applicablePackage.price + (extraHours * pricePerHour);
+  // Round to nearest rupee (>= .50 up, < .50 down) so no float values are shown
+  return Math.round(applicablePackage.price + (extraHours * pricePerHour));
 }
 
 // Legacy function - kept for backward compatibility


### PR DESCRIPTION
- Staff bookings: show last 7 + next 7 days (window, inputs, banner text)
- Agent form: fix Valid From shifting back a day on each edit by treating dates as pure yyyy-MM-dd and saving at noon UTC
- Admin sidebar: move Dashboard above Agent Management
- Packages: round prices at source (no float values shown)
- Booking 24h cycle: default return time mirrors pickup time