### PR TITLE
feat: admin dashboard redesign, geofence city auto-fill, and instant booking cancel

### DIFF
--- a/src/components/admin/BookingsTab.tsx
+++ b/src/components/admin/BookingsTab.tsx
@@ -1,30 +1,98 @@
-import React, { useState } from 'react';
-import { CheckCircle, XCircle, ChevronDown, Download } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Eye, Download, Search, X, Ban, CheckCircle, Check,
+  ArrowUpRight, Bike,
+} from 'lucide-react';
 import { toast } from 'sonner';
 
 import {
   useGetBookingsQuery,
   useUpdateBookingMutation,
+  useSuperAdminCancelBookingMutation,
+  type BookingDto,
 } from '../../store/api/bookingApi';
-import { useDashboardCityFilter } from './DashboardCityFilter';
+import { useGetUsersQuery, type UserDto } from '../../store/api/userApi';
+import { useGetAdminBookingCustomerDetailsQuery } from '../../store/api/bookingCustomerDetailsApi';
+import { useAppSelector } from '../../store/hooks';
+import DashboardCityFilter, { useDashboardCityFilter } from './DashboardCityFilter';
 import { LoadingSpinner } from '../../components/LoadingSpinner';
 import { exportToExcel, formatBookingsForExport, formatPaymentsForExport } from '../../utils/excelExport';
 
-const BookingsTab: React.FC = () => {
-  const [bookingSort, setBookingSort] = useState<{ column: string; direction: 'asc' | 'desc' }>({
-    column: 'id', direction: 'desc',
-  });
+// ── Status helpers ──────────────────────────────────────────────────────────
+type StatusMeta = { label: string; stripe: string; iconBg: string; badge: string; dot: string; activeTab: string };
+const STATUS_META: Record<number, StatusMeta> = {
+  0: { label: 'Pending',   stripe: 'border-yellow-400', iconBg: 'bg-yellow-50 text-yellow-600',  badge: 'bg-yellow-100 text-yellow-700', dot: 'bg-yellow-400', activeTab: 'bg-yellow-100 text-yellow-800' },
+  1: { label: 'Confirmed', stripe: 'border-green-500',  iconBg: 'bg-primary-50 text-primary-600', badge: 'bg-green-100 text-green-700',  dot: 'bg-green-500',  activeTab: 'bg-green-100 text-green-800' },
+  2: { label: 'Completed', stripe: 'border-blue-400',   iconBg: 'bg-blue-50 text-blue-600',       badge: 'bg-blue-100 text-blue-700',   dot: 'bg-blue-400',   activeTab: 'bg-blue-100 text-blue-800' },
+  3: { label: 'Cancelled', stripe: 'border-red-400',    iconBg: 'bg-red-50 text-red-500',         badge: 'bg-red-100 text-red-700',     dot: 'bg-red-400',    activeTab: 'bg-red-100 text-red-800' },
+};
+const statusMeta = (s: number): StatusMeta => STATUS_META[s] ?? STATUS_META[0];
 
-  // Get city filter from Redux
+const STATUS_FILTERS: { label: string; value: 'all' | 0 | 1 | 2 | 3; dot?: string; activeTab?: string }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Pending', value: 0, dot: STATUS_META[0].dot, activeTab: STATUS_META[0].activeTab },
+  { label: 'Confirmed', value: 1, dot: STATUS_META[1].dot, activeTab: STATUS_META[1].activeTab },
+  { label: 'Completed', value: 2, dot: STATUS_META[2].dot, activeTab: STATUS_META[2].activeTab },
+  { label: 'Cancelled', value: 3, dot: STATUS_META[3].dot, activeTab: STATUS_META[3].activeTab },
+];
+
+// A booking is still cancellable only while its rental period hasn't ended yet.
+const isBookingActive = (endDate?: string) => {
+  if (!endDate) return false;
+  const end = new Date(endDate);
+  if (Number.isNaN(end.getTime())) return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  end.setHours(0, 0, 0, 0);
+  return end >= today;
+};
+
+const fmtDate = (d?: string) => {
+  if (!d) return '—';
+  const date = new Date(d);
+  if (Number.isNaN(date.getTime())) return String(d);
+  return date.toLocaleDateString('en-IN', { day: '2-digit', month: 'short' });
+};
+
+const fmtDateTime = (d?: string, time?: string) => {
+  if (!d) return '—';
+  const date = new Date(d);
+  const base = Number.isNaN(date.getTime())
+    ? String(d)
+    : date.toLocaleDateString('en-IN', { day: '2-digit', month: 'short', year: 'numeric' });
+  return time ? `${base}, ${time}` : base;
+};
+
+const customerLabel = (u?: UserDto, userId?: number) =>
+  u?.name?.trim() || u?.userNumber || `Customer #${userId ?? '—'}`;
+
+const BookingsTab: React.FC = () => {
+  const navigate = useNavigate();
+  const [statusFilter, setStatusFilter] = useState<'all' | 0 | 1 | 2 | 3>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedBooking, setSelectedBooking] = useState<BookingDto | null>(null);
+
+  // Only SuperAdmin can force-cancel any booking (frees the vehicle instantly)
+  const adminUser = useAppSelector((state) => state.auth.user);
+  const isSuperAdmin = adminUser?.userType === 'superadmin';
+
   const { cityIdParam } = useDashboardCityFilter();
 
   // ── API Calls ──────────────────────────────────────────────────────────
-  const { data: bookings = [], isLoading: bookingsLoading, refetch: refetchBookings } = useGetBookingsQuery({ 
-    page: 1, 
-    size: 100,
-    cityId: cityIdParam
+  const { data: bookings = [], isLoading: bookingsLoading, refetch: refetchBookings } = useGetBookingsQuery({
+    page: 1, size: 100, cityId: cityIdParam,
   });
+  const { data: users = [] } = useGetUsersQuery({ page: 1, size: 1000 });
   const [updateBooking] = useUpdateBookingMutation();
+  const [superAdminCancelBooking, { isLoading: isCancelling }] = useSuperAdminCancelBookingMutation();
+
+  // userId → user map (single fetch, no N+1)
+  const userMap = useMemo(() => {
+    const m = new Map<number, UserDto>();
+    users.forEach((u) => m.set(u.id, u));
+    return m;
+  }, [users]);
 
   // ── Handlers ──────────────────────────────────────────────────────────
   const handleUpdateBookingStatus = async (bookingId: number, status: 0 | 1 | 2 | 3) => {
@@ -33,156 +101,371 @@ const BookingsTab: React.FC = () => {
       if (!booking) return;
       await updateBooking({ id: bookingId, booking: { ...booking, status } }).unwrap();
       toast.success('Booking status updated');
+      setSelectedBooking(null);
       refetchBookings();
     } catch { toast.error('Failed to update booking'); }
   };
 
-  const handleSortBookings = (column: string) => {
-    setBookingSort((prev) =>
-      prev.column === column
-        ? { column, direction: prev.direction === 'asc' ? 'desc' : 'asc' }
-        : { column, direction: 'asc' }
-    );
+  const handleSuperAdminCancel = async (bookingId: number) => {
+    if (!window.confirm('Cancel this booking? The vehicle will become available instantly.')) return;
+    try {
+      await superAdminCancelBooking(bookingId).unwrap();
+      toast.success('Booking cancelled. Vehicle is now available.');
+      setSelectedBooking(null);
+      refetchBookings();
+    } catch (err: any) {
+      toast.error(err?.data?.error ?? 'Failed to cancel booking');
+    }
   };
 
-  // ── Sorted Data ────────────────────────────────────────────────────────
-  const sortedBookings = [...bookings].sort((a, b) => {
-    const aVal = (a as any)[bookingSort.column];
-    const bVal = (b as any)[bookingSort.column];
-    if (aVal < bVal) return bookingSort.direction === 'asc' ? -1 : 1;
-    if (aVal > bVal) return bookingSort.direction === 'asc' ? 1 : -1;
-    return 0;
-  });
+  const goToUser = (userId: number) => navigate(`/users?highlight=${userId}`);
+  const goToVehicle = (vehicleId: number) => navigate(`/vehicles?highlight=${vehicleId}`);
 
-  const getStatusBadge = (status: number) => {
-    const map: Record<number, { text: string; color: string }> = {
-      0: { text: 'Pending', color: 'bg-yellow-100 text-yellow-800' },
-      1: { text: 'Confirmed', color: 'bg-green-100 text-green-800' },
-      2: { text: 'Completed', color: 'bg-primary-100 text-blue-800' },
-      3: { text: 'Cancelled', color: 'bg-red-100 text-red-800' },
-    };
-    const { text, color } = map[status] ?? { text: 'Unknown', color: 'bg-gray-100 text-gray-800' };
-    return <span className={`px-2 py-1 rounded-full text-xs font-semibold ${color}`}>{text}</span>;
-  };
-
-  const SortIcon = ({ column }: { column: string }) => (
-    <button onClick={() => handleSortBookings(column)} className="flex items-center ml-1">
-      <ChevronDown className={`w-4 h-4 ${bookingSort.column === column ? 'text-primary-600' : 'text-gray-400'}`} />
-    </button>
-  );
+  // ── Filtered Data ──────────────────────────────────────────────────────
+  const filteredBookings = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    return bookings
+      .filter((b) => (statusFilter === 'all' ? true : b.status === statusFilter))
+      .filter((b) => {
+        if (!q) return true;
+        const user = b.userId != null ? userMap.get(b.userId) : undefined;
+        return (
+          String(b.id ?? '').includes(q) ||
+          (b.vehicleName ?? '').toLowerCase().includes(q) ||
+          (b.vehicleRegistrationNumber ?? '').toLowerCase().includes(q) ||
+          customerLabel(user, b.userId).toLowerCase().includes(q)
+        );
+      })
+      .sort((a, b) => (b.id ?? 0) - (a.id ?? 0));
+  }, [bookings, statusFilter, searchQuery, userMap]);
 
   // ── Export Handlers ─────────────────────────────────────────────────────
   const handleExportBookings = () => {
-    if (bookings.length === 0) {
-      toast.error('No bookings to export');
-      return;
-    }
-    const data = formatBookingsForExport(bookings);
-    exportToExcel(data, 'Bookings', 'Bookings');
+    if (bookings.length === 0) { toast.error('No bookings to export'); return; }
+    exportToExcel(formatBookingsForExport(bookings), 'Bookings', 'Bookings');
     toast.success('Bookings exported successfully');
   };
-
   const handleExportPayments = () => {
-    if (bookings.length === 0) {
-      toast.error('No payment data to export');
-      return;
-    }
-    const data = formatPaymentsForExport(bookings);
-    exportToExcel(data, 'Payments', 'Payments');
+    if (bookings.length === 0) { toast.error('No payment data to export'); return; }
+    exportToExcel(formatPaymentsForExport(bookings), 'Payments', 'Payments');
     toast.success('Payments exported successfully');
   };
 
   return (
     <div>
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4 lg:mb-6">
-        <h1 className="text-2xl lg:text-3xl font-bold text-gray-900">Booking Management</h1>
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+          <h1 className="text-2xl lg:text-3xl font-extrabold text-gray-900">Booking Management</h1>
+          <p className="text-sm text-gray-500 mt-1">Manage, track and act on all rental bookings</p>
+        </div>
         <div className="flex gap-2">
-          <button
-            onClick={handleExportBookings}
-            className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition text-sm font-medium"
-          >
-            <Download className="w-4 h-4" />
-            Export Bookings
+          <button onClick={handleExportBookings} className="flex items-center gap-2 px-4 py-2.5 bg-white border border-gray-200 text-gray-700 rounded-xl hover:bg-gray-50 transition text-sm font-semibold shadow-sm">
+            <Download className="w-4 h-4 text-green-600" /> Export Bookings
           </button>
-          <button
-            onClick={handleExportPayments}
-            className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition text-sm font-medium"
-          >
-            <Download className="w-4 h-4" />
-            Export Payments
+          <button onClick={handleExportPayments} className="flex items-center gap-2 px-4 py-2.5 bg-white border border-gray-200 text-gray-700 rounded-xl hover:bg-gray-50 transition text-sm font-semibold shadow-sm">
+            <Download className="w-4 h-4 text-blue-600" /> Export Payments
           </button>
         </div>
       </div>
-      {bookingsLoading ? <LoadingSpinner /> : (
-        <div className="bg-white rounded-xl shadow-md overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[800px]">
-              <thead className="bg-gray-50">
-                <tr>
-                  {[
-                    { label: 'Booking ID', col: 'id' },
-                    { label: 'Vehicle ID', col: 'vehicleId' },
-                    { label: 'Customer ID', col: 'userId' },
-                    { label: 'F&F Contact', col: 'friendFamilyContactNumber' },
-                    { label: 'Start Date', col: 'bookingStartDate' },
-                    { label: 'Amount', col: 'totalAmount' },
-                    { label: 'Status', col: null },
-                    { label: 'Actions', col: null },
-                  ].map(({ label, col }) => (
-                    <th key={label} className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase">
-                      {col ? (
-                        <button onClick={() => handleSortBookings(col)} className="flex items-center">
-                          {label}<SortIcon column={col} />
-                        </button>
-                      ) : label}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200">
-                {sortedBookings.map((booking) => (
-                  <tr key={booking.id} className="hover:bg-gray-50 transition">
-                    <td className="px-6 py-4 font-medium text-gray-900">#{booking.id}</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">Vehicle #{booking.vehicleId}</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">Customer #{booking.userId}</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">
-                      {booking.friendFamilyContactNumber || <span className="text-gray-400">—</span>}
-                    </td>
-                    <td className="px-6 py-4 text-sm text-gray-600">
-                      {String(booking.bookingStartDate)} → {String(booking.bookingEndDate)}
-                    </td>
-                    <td className="px-6 py-4 text-sm font-semibold text-gray-900">₹{booking.totalAmount}</td>
-                    <td className="px-6 py-4">{getStatusBadge(booking.status)}</td>
-                    <td className="px-6 py-4">
-                      <div className="flex space-x-2">
-                        {booking.status === 0 && (
-                          <>
-                            <button onClick={() => handleUpdateBookingStatus(booking.id!, 1)} className="p-2 text-green-600 hover:bg-green-50 rounded-lg transition" title="Confirm">
-                              <CheckCircle className="w-4 h-4" />
-                            </button>
-                            <button onClick={() => handleUpdateBookingStatus(booking.id!, 3)} className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition" title="Cancel">
-                              <XCircle className="w-4 h-4" />
-                            </button>
-                          </>
-                        )}
-                        {booking.status === 1 && (
-                          <button onClick={() => handleUpdateBookingStatus(booking.id!, 2)} className="px-3 py-1 text-xs bg-primary-100 text-primary-700 rounded-lg hover:bg-primary-200">
-                            Mark Complete
-                          </button>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-                {sortedBookings.length === 0 && (
-                  <tr><td colSpan={8} className="px-6 py-12 text-center text-gray-500">No bookings found</td></tr>
-                )}
-              </tbody>
-            </table>
+
+      {/* Toolbar: search + status tabs */}
+      <div className="bg-white rounded-2xl p-4 shadow-sm border border-gray-100 mb-5">
+        <div className="flex flex-col lg:flex-row lg:items-center gap-3">
+          <div className="relative flex-1">
+            <Search className="w-4 h-4 absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search by booking ID, vehicle, customer..."
+              className="w-full pl-10 pr-4 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-200 focus:border-primary-400"
+            />
+          </div>
+          <DashboardCityFilter />
+          <div className="flex items-center gap-1 bg-gray-100 p-1 rounded-xl overflow-x-auto">
+            {STATUS_FILTERS.map((f) => {
+              const active = statusFilter === f.value;
+              const activeClass = active
+                ? f.activeTab
+                  ? `${f.activeTab} font-semibold shadow-sm`
+                  : 'bg-white text-primary-700 font-semibold shadow-sm'
+                : 'text-gray-500 hover:text-gray-800 font-medium';
+              return (
+                <button
+                  key={f.label}
+                  onClick={() => setStatusFilter(f.value)}
+                  className={`px-3.5 py-1.5 rounded-lg text-sm whitespace-nowrap transition inline-flex items-center gap-1.5 ${activeClass}`}
+                >
+                  {f.dot && <span className={`w-2 h-2 rounded-full ${f.dot}`} />}
+                  {f.label}
+                </button>
+              );
+            })}
           </div>
         </div>
+      </div>
+
+      {bookingsLoading ? <LoadingSpinner /> : (
+        <>
+          {/* Column header (desktop) */}
+          <div className="hidden lg:grid px-5 mb-2 gap-4 items-center text-[11px] font-bold uppercase tracking-wide text-gray-400"
+               style={{ gridTemplateColumns: '260px 1.3fr 1.1fr 1fr 0.9fr 80px' }}>
+            <span>Booking / Vehicle</span>
+            <span>Customer</span>
+            <span>Dates</span>
+            <span>Phone</span>
+            <span className="text-right">Amount</span>
+            <span className="text-right">Action</span>
+          </div>
+
+          <div className="space-y-2.5">
+            {filteredBookings.map((booking) => {
+              const meta = statusMeta(booking.status);
+              const user = booking.userId != null ? userMap.get(booking.userId) : undefined;
+              const muted = booking.status === 2 || booking.status === 3;
+              return (
+                <div key={booking.id} className={`bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden hover:shadow-md transition ${muted ? 'opacity-80' : ''}`}>
+                  <div className={`border-l-4 ${meta.stripe} px-5 py-4 grid gap-3 lg:gap-4 items-center grid-cols-1 lg:[grid-template-columns:260px_1.3fr_1.1fr_1fr_0.9fr_80px]`}>
+                    {/* Booking / Vehicle */}
+                    <div className="flex items-center gap-3">
+                      <div className={`w-11 h-11 rounded-xl ${meta.iconBg} flex items-center justify-center shrink-0`}>
+                        <Bike className="w-5 h-5" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="font-bold text-gray-900">#{booking.id}</p>
+                        <button
+                          onClick={() => goToVehicle(booking.vehicleId)}
+                          className="text-xs text-primary-600 hover:underline truncate block max-w-[180px] text-left"
+                          title="View vehicle"
+                        >
+                          {booking.vehicleName || `Vehicle #${booking.vehicleId}`}
+                          {booking.vehicleRegistrationNumber ? ` · ${booking.vehicleRegistrationNumber}` : ''}
+                        </button>
+                      </div>
+                    </div>
+                    {/* Customer */}
+                    <div className="min-w-0">
+                      <p className="lg:hidden text-[11px] uppercase text-gray-400 font-semibold">Customer</p>
+                      <button
+                        onClick={() => booking.userId != null && goToUser(booking.userId)}
+                        className="font-medium text-primary-600 hover:underline truncate inline-flex items-center gap-1 max-w-full text-left"
+                        title="View customer"
+                      >
+                        <span className="truncate">{customerLabel(user, booking.userId)}</span>
+                        <ArrowUpRight className="w-3 h-3 shrink-0" />
+                      </button>
+                    </div>
+                    {/* Dates */}
+                    <div>
+                      <p className="lg:hidden text-[11px] uppercase text-gray-400 font-semibold">Dates</p>
+                      <p className="font-medium text-gray-800 text-sm">{fmtDate(booking.bookingStartDate)} → {fmtDate(booking.bookingEndDate)}</p>
+                    </div>
+                    {/* Phone */}
+                    <div className="min-w-0">
+                      <p className="lg:hidden text-[11px] uppercase text-gray-400 font-semibold">Phone</p>
+                      <p className="font-medium text-gray-800 text-sm truncate">{user?.userNumber ?? booking.friendFamilyContactNumber ?? '—'}</p>
+                    </div>
+                    {/* Amount */}
+                    <div className="lg:text-right">
+                      <p className="lg:hidden text-[11px] uppercase text-gray-400 font-semibold">Amount</p>
+                      <p className="font-bold text-gray-900">₹{booking.totalAmount}</p>
+                    </div>
+                    {/* Action */}
+                    <div className="flex lg:justify-end">
+                      <button
+                        onClick={() => setSelectedBooking(booking)}
+                        className="w-9 h-9 flex items-center justify-center rounded-lg bg-gray-100 text-gray-600 hover:bg-gray-200 transition"
+                        title="View booking details"
+                      >
+                        <Eye className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+            {filteredBookings.length === 0 && (
+              <div className="bg-white rounded-2xl border border-gray-100 shadow-sm px-6 py-16 text-center text-gray-500">
+                No bookings found
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* View Booking drawer */}
+      {selectedBooking && (
+        <BookingDetailDrawer
+          booking={selectedBooking}
+          user={selectedBooking.userId != null ? userMap.get(selectedBooking.userId) : undefined}
+          isSuperAdmin={!!isSuperAdmin}
+          isCancelling={isCancelling}
+          onClose={() => setSelectedBooking(null)}
+          onUpdateStatus={handleUpdateBookingStatus}
+          onSuperAdminCancel={handleSuperAdminCancel}
+          onOpenUser={goToUser}
+          onOpenVehicle={goToVehicle}
+        />
       )}
     </div>
+  );
+};
+
+// ── View Booking Drawer ─────────────────────────────────────────────────────
+interface DrawerProps {
+  booking: BookingDto;
+  user?: UserDto;
+  isSuperAdmin: boolean;
+  isCancelling: boolean;
+  onClose: () => void;
+  onUpdateStatus: (id: number, status: 0 | 1 | 2 | 3) => void;
+  onSuperAdminCancel: (id: number) => void;
+  onOpenUser: (id: number) => void;
+  onOpenVehicle: (id: number) => void;
+}
+
+const DetailRow: React.FC<{ label: string; value?: React.ReactNode }> = ({ label, value }) => (
+  <div>
+    <p className="text-gray-400 text-xs">{label}</p>
+    <p className="font-medium text-gray-800 break-words">{value || '—'}</p>
+  </div>
+);
+
+const BookingDetailDrawer: React.FC<DrawerProps> = ({
+  booking, user, isSuperAdmin, isCancelling, onClose,
+  onUpdateStatus, onSuperAdminCancel, onOpenUser, onOpenVehicle,
+}) => {
+  const meta = statusMeta(booking.status);
+  const { data: details, isLoading: detailsLoading, isError: detailsError } =
+    useGetAdminBookingCustomerDetailsQuery(booking.id as number, { skip: booking.id == null });
+
+  const canCancel = isSuperAdmin && (booking.status === 0 || booking.status === 1) && isBookingActive(booking.bookingEndDate);
+
+  return (
+    <>
+      <div onClick={onClose} className="fixed inset-0 bg-black/40 z-40 transition-opacity" />
+      <div className="fixed top-0 right-0 h-full w-full max-w-md bg-gray-50 shadow-2xl z-50 overflow-y-auto">
+        {/* Header */}
+        <div className="sticky top-0 bg-white border-b border-gray-100 px-5 py-4 flex items-center justify-between z-10">
+          <div>
+            <p className="text-xs text-gray-400 font-semibold uppercase tracking-wide">Booking Details</p>
+            <h3 className="text-lg font-extrabold text-gray-900 flex items-center gap-2">
+              #{booking.id} <span className={`px-2 py-0.5 rounded-full text-xs ${meta.badge}`}>{meta.label}</span>
+            </h3>
+          </div>
+          <button onClick={onClose} className="w-9 h-9 rounded-lg hover:bg-gray-100 text-gray-500 flex items-center justify-center">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          {/* Customer */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-4">
+            <div className="flex items-center justify-between mb-3">
+              <h4 className="text-xs font-bold uppercase text-gray-400 tracking-wide">Customer</h4>
+              {booking.userId != null && (
+                <button onClick={() => onOpenUser(booking.userId)} className="text-xs text-primary-600 hover:underline font-semibold inline-flex items-center gap-1">
+                  Open profile <ArrowUpRight className="w-3 h-3" />
+                </button>
+              )}
+            </div>
+            <div className="grid grid-cols-2 gap-y-3 gap-x-4 text-sm">
+              <DetailRow label="Name" value={user?.name || customerLabel(user, booking.userId)} />
+              <DetailRow label="Phone" value={user?.userNumber} />
+              <DetailRow label="Email" value={user?.email} />
+            </div>
+          </div>
+
+          {/* Vehicle */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-4">
+            <div className="flex items-center justify-between mb-3">
+              <h4 className="text-xs font-bold uppercase text-gray-400 tracking-wide">Vehicle</h4>
+              <button onClick={() => onOpenVehicle(booking.vehicleId)} className="text-xs text-primary-600 hover:underline font-semibold inline-flex items-center gap-1">
+                Open vehicle <ArrowUpRight className="w-3 h-3" />
+              </button>
+            </div>
+            <div className="flex items-center gap-3">
+              <div className="w-11 h-11 rounded-xl bg-primary-50 text-primary-600 flex items-center justify-center"><Bike className="w-5 h-5" /></div>
+              <div>
+                <p className="font-bold text-gray-900">{booking.vehicleName || `Vehicle #${booking.vehicleId}`}</p>
+                <p className="text-sm text-gray-500">
+                  {[booking.vehicleRegistrationNumber, booking.vehicleMake, booking.vehicleModel].filter(Boolean).join(' · ') || '—'}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Trip */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-4">
+            <h4 className="text-xs font-bold uppercase text-gray-400 tracking-wide mb-3">Trip</h4>
+            <div className="grid grid-cols-2 gap-y-3 gap-x-4 text-sm">
+              <DetailRow label="Pickup" value={fmtDateTime(booking.bookingStartDate, booking.startTime)} />
+              <DetailRow label="Return" value={fmtDateTime(booking.bookingEndDate, booking.endTime)} />
+              <DetailRow label="Pickup Location" value={booking.pickupLocationName} />
+              <DetailRow label="2nd Helmet" value={booking.includeSecondHelmet ? 'Yes' : 'No'} />
+            </div>
+          </div>
+
+          {/* Submitted Details */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-4">
+            <h4 className="text-xs font-bold uppercase text-gray-400 tracking-wide mb-3">Submitted Details</h4>
+            {detailsLoading ? (
+              <p className="text-sm text-gray-400">Loading…</p>
+            ) : detailsError || !details ? (
+              <p className="text-sm text-gray-400">No customer details submitted for this booking.</p>
+            ) : (
+              <div className="space-y-3 text-sm">
+                <DetailRow label="Guest Address" value={details.guestAddress} />
+                <div className="grid grid-cols-2 gap-x-4">
+                  <DetailRow label="Hotel Name" value={details.hotelName} />
+                  <DetailRow label="Hotel Address" value={details.hotelAddress} />
+                </div>
+                <div className="grid grid-cols-2 gap-x-4">
+                  <DetailRow label="F&F Contact" value={details.friendFamilyContactNumber} />
+                  <DetailRow label="Driving License No." value={details.drivingLicenseNo} />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Payment */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-4">
+            <h4 className="text-xs font-bold uppercase text-gray-400 tracking-wide mb-3">Payment</h4>
+            <div className="space-y-2 text-sm">
+              <div className="flex justify-between"><span className="text-gray-500">Total amount</span><span className="font-bold text-gray-900">₹{booking.totalAmount}</span></div>
+              <div className="flex justify-between"><span className="text-gray-500">Security deposit</span><span className="font-medium">{booking.securityDepositMode === 'online' ? 'Paid online' : 'At pickup'}</span></div>
+              <div className="flex justify-between"><span className="text-gray-500">Payment status</span><span className="font-medium capitalize">{booking.paymentStatus ?? '—'}</span></div>
+              {booking.transactionId && (
+                <div className="flex justify-between"><span className="text-gray-500">Transaction ID</span><span className="font-mono text-xs">{booking.transactionId}</span></div>
+              )}
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex flex-wrap gap-2 pb-6">
+            {booking.status === 0 && (
+              <button onClick={() => onUpdateStatus(booking.id as number, 1)} className="flex-1 min-w-[120px] px-4 py-2.5 text-sm font-semibold rounded-xl bg-green-600 text-white hover:bg-green-700 inline-flex items-center justify-center gap-1">
+                <Check className="w-4 h-4" /> Confirm
+              </button>
+            )}
+            {booking.status === 1 && (
+              <button onClick={() => onUpdateStatus(booking.id as number, 2)} className="flex-1 min-w-[120px] px-4 py-2.5 text-sm font-semibold rounded-xl bg-primary-600 text-white hover:bg-primary-700 inline-flex items-center justify-center gap-1">
+                <CheckCircle className="w-4 h-4" /> Mark Complete
+              </button>
+            )}
+            {canCancel && (
+              <button onClick={() => onSuperAdminCancel(booking.id as number)} disabled={isCancelling} className="flex-1 min-w-[120px] px-4 py-2.5 text-sm font-semibold rounded-xl bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 inline-flex items-center justify-center gap-1">
+                <Ban className="w-4 h-4" /> Cancel & Free
+              </button>
+            )}
+            {(booking.status === 2 || booking.status === 3) && (
+              <p className="text-sm text-gray-400 italic w-full text-center py-2">No actions available for {meta.label.toLowerCase()} bookings.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/src/components/admin/GeofencesTab.tsx
+++ b/src/components/admin/GeofencesTab.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import {
   Plus, Edit, Trash2, Search, MapPin, X, Save, Loader2,
-  Circle, Hexagon, Car
+  Circle, Hexagon, Car, Wand2
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { GoogleMap, useJsApiLoader, Polygon, Circle as GoogleCircle, DrawingManager } from '@react-google-maps/api';
@@ -15,7 +15,7 @@ import {
   type CreateGeofenceDto,
   type GeoCoordinateDto,
 } from '../../store/api/geofenceApi';
-import { useGetCitiesQuery } from '../../store/api/cityApi';
+import { useGetCitiesQuery, useGetStatesQuery } from '../../store/api/cityApi';
 import { LoadingSpinner } from '../LoadingSpinner';
 import { FormField } from './FormField';
 
@@ -75,6 +75,7 @@ const GeofencesTab: React.FC<GeofencesTabProps> = ({ adminCityIds = [], isSuperA
   const [isDrawing, setIsDrawing] = useState(false);
   const [mapCenter, setMapCenter] = useState(DEFAULT_CENTER);
   const [mapKey, setMapKey] = useState(0); // Force map re-render when clearing
+  const [autoFilling, setAutoFilling] = useState(false);
   
   const polygonRef = useRef<google.maps.Polygon | null>(null);
   const circleRef = useRef<google.maps.Circle | null>(null);
@@ -82,6 +83,7 @@ const GeofencesTab: React.FC<GeofencesTabProps> = ({ adminCityIds = [], isSuperA
   // API queries
   const { data: geofences = [], isLoading, refetch } = useGetGeofencesQuery();
   const { data: cities = [] } = useGetCitiesQuery({ page: 1, size: 100 });
+  const { data: states = [] } = useGetStatesQuery({ page: 1, size: 100 });
   const [createGeofence, { isLoading: creating }] = useCreateGeofenceMutation();
   const [updateGeofence, { isLoading: updating }] = useUpdateGeofenceMutation();
   const [deleteGeofence] = useDeleteGeofenceMutation();
@@ -234,6 +236,125 @@ const GeofencesTab: React.FC<GeofencesTabProps> = ({ adminCityIds = [], isSuperA
     setIsDrawing(false);
     // Force map re-render to clear any leftover overlays
     setMapKey(prev => prev + 1);
+  };
+
+  // Reduce a dense boundary ring to a manageable number of points
+  const decimate = (pts: GeoCoordinateDto[], max = 80): GeoCoordinateDto[] => {
+    if (pts.length <= max) return pts;
+    const step = Math.ceil(pts.length / max);
+    const out: GeoCoordinateDto[] = [];
+    for (let i = 0; i < pts.length; i += step) out.push(pts[i]);
+    return out;
+  };
+
+  // Auto-fill the geofence with the selected city's real boundary (OpenStreetMap/Nominatim).
+  // Falls back to the city bounding box if no boundary polygon is available.
+  const autoFillCityBoundary = async () => {
+    const city = cities.find(c => c.id === geofenceForm.cityId);
+    if (!city) { toast.error('Please select a city first'); return; }
+    const state = states.find(s => s.id === city.stateId);
+    setAutoFilling(true);
+
+    type NomResult = {
+      geojson?: { type: string; coordinates: unknown };
+      class?: string;
+      type?: string;
+      osm_type?: string;
+      addresstype?: string;
+      display_name?: string;
+      extratags?: { admin_level?: string };
+    };
+
+    const ringFromGeo = (geo?: { type: string; coordinates: unknown }): number[][] | null => {
+      if (!geo) return null;
+      if (geo.type === 'Polygon') {
+        return (geo.coordinates as number[][][])[0] ?? null;
+      }
+      if (geo.type === 'MultiPolygon') {
+        let best: number[][] = [];
+        (geo.coordinates as number[][][][]).forEach((poly) => {
+          if (poly[0] && poly[0].length > best.length) best = poly[0];
+        });
+        return best.length ? best : null;
+      }
+      return null;
+    };
+
+    // Prefer the CITY/municipal boundary (admin_level 8) over the larger
+    // district (5/6) or state (4) boundary.
+    const levelOf = (d?: NomResult): number => {
+      const lvl = Number(d?.extratags?.admin_level);
+      if (!Number.isNaN(lvl)) return lvl;
+      if (d?.addresstype === 'city' || d?.addresstype === 'municipality' || d?.addresstype === 'town') return 8;
+      return 99;
+    };
+
+    // Fetch results from a query and return the best matching boundary.
+    // Returns { ring, level } so the caller can decide if it's city-level enough.
+    const fetchBest = async (search: string): Promise<{ ring: number[][]; level: number } | null> => {
+      const qs = new URLSearchParams({
+        q: search,
+        format: 'json',
+        polygon_geojson: '1',
+        extratags: '1',
+        addressdetails: '1',
+        limit: '15',
+      });
+      const res = await fetch(`https://nominatim.openstreetmap.org/search?${qs.toString()}`, {
+        headers: { Accept: 'application/json' },
+      });
+      const data = (await res.json()) as NomResult[];
+      const candidates = (data ?? []).filter(
+        d => d.osm_type === 'relation' && (d.class === 'boundary' || d.type === 'administrative') && ringFromGeo(d.geojson)
+      );
+      if (!candidates.length) return null;
+      // Closest to admin_level 8 (the city) wins.
+      const sorted = [...candidates].sort((a, b) => Math.abs(levelOf(a) - 8) - Math.abs(levelOf(b) - 8));
+      const best = sorted[0];
+      const ring = ringFromGeo(best.geojson)!;
+      return { ring, level: levelOf(best) };
+    };
+
+    try {
+      // Try queries in priority order. Indian city limits are usually tagged as a
+      // "Municipal Corporation" / "Nagar Nigam" (admin_level 8) relation, which a plain
+      // "City, State" search does NOT return (it returns the bigger district instead).
+      const queries = [
+        `${city.name} Municipal Corporation, ${state?.name ?? ''}, India`,
+        `${city.name} Nagar Nigam, ${state?.name ?? ''}, India`,
+        `${city.name}, ${state?.name ?? ''}, India`,
+      ].map(q => q.replace(/\s*,\s*,/g, ',').trim());
+
+      let ring: number[][] | null = null;
+      let fallbackRing: number[][] | null = null;
+
+      for (const q of queries) {
+        const result = await fetchBest(q);
+        if (!result) continue;
+        if (!fallbackRing) fallbackRing = result.ring; // remember first hit as a backup
+        if (result.level === 8) { ring = result.ring; break; } // exact city boundary
+      }
+
+      // Use the city-level boundary if found, else the best thing we got.
+      ring = ring ?? fallbackRing;
+
+      if (ring && ring.length >= 3) {
+        const coords = decimate(ring.map(([lng, lat]) => ({ lat, lng })));
+        const cLat = coords.reduce((s, c) => s + c.lat, 0) / coords.length;
+        const cLng = coords.reduce((s, c) => s + c.lng, 0) / coords.length;
+        setGeofenceForm(prev => ({ ...prev, fenceType: 'polygon', coordinates: coords }));
+        setMapCenter({ lat: cLat, lng: cLng });
+        setMapKey(k => k + 1);
+        toast.success(`Auto-filled ${city.name} boundary (${coords.length} points). Drag points to adjust if needed.`);
+        return;
+      }
+
+      toast.error(`Exact boundary not found for ${city.name}. Please draw it manually.`);
+    } catch {
+      toast.error('Failed to fetch city boundary');
+    } finally {
+      setAutoFilling(false);
+    }
   };
 
   // Update map center when city changes
@@ -444,6 +565,18 @@ const GeofencesTab: React.FC<GeofencesTabProps> = ({ adminCityIds = [], isSuperA
                     Draw Geofence on Map
                   </label>
                   <div className="flex gap-2">
+                    {geofenceForm.fenceType === 'polygon' && (
+                      <button
+                        type="button"
+                        onClick={autoFillCityBoundary}
+                        disabled={autoFilling || !geofenceForm.cityId}
+                        title={geofenceForm.cityId ? 'Auto-select the city boundary' : 'Select a city first'}
+                        className="px-3 py-1.5 text-sm bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1.5"
+                      >
+                        {autoFilling ? <Loader2 className="w-4 h-4 animate-spin" /> : <Wand2 className="w-4 h-4" />}
+                        Auto-fill City
+                      </button>
+                    )}
                     <button
                       type="button"
                       onClick={() => setIsDrawing(true)}
@@ -517,10 +650,26 @@ const GeofencesTab: React.FC<GeofencesTabProps> = ({ adminCityIds = [], isSuperA
                       />
                     )}
 
-                    {/* Show existing polygon */}
+                    {/* Show existing polygon (editable: drag vertices to fine-tune) */}
                     {!isDrawing && geofenceForm.fenceType === 'polygon' && geofenceForm.coordinates && geofenceForm.coordinates.length > 0 && (
                       <Polygon
+                        editable
                         paths={geofenceForm.coordinates.map(c => ({ lat: c.lat, lng: c.lng }))}
+                        onLoad={(polygon) => {
+                          const sync = () => {
+                            const path = polygon.getPath();
+                            const coords: GeoCoordinateDto[] = [];
+                            for (let i = 0; i < path.getLength(); i++) {
+                              const p = path.getAt(i);
+                              coords.push({ lat: p.lat(), lng: p.lng() });
+                            }
+                            setGeofenceForm(prev => ({ ...prev, coordinates: coords }));
+                          };
+                          const path = polygon.getPath();
+                          path.addListener('set_at', sync);
+                          path.addListener('insert_at', sync);
+                          path.addListener('remove_at', sync);
+                        }}
                         options={{
                           fillColor: '#8B5CF6',
                           fillOpacity: 0.3,

--- a/src/components/admin/UsersTab.tsx
+++ b/src/components/admin/UsersTab.tsx
@@ -1,110 +1,387 @@
-import React, { useState } from 'react';
-import { Search, Trash2, Download } from 'lucide-react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  Search, Download, Eye, X, Phone, Mail, MapPin,
+  Users as UsersIcon, UserCheck, UserPlus, Bike, IdCard,
+} from 'lucide-react';
 import { toast } from 'sonner';
 
 import {
   useGetUsersQuery,
-  useDeleteUserMutation,
+  type UserDto,
 } from '../../store/api/userApi';
+import { useGetBookingsQuery, type BookingDto } from '../../store/api/bookingApi';
+import { useGetCitiesQuery } from '../../store/api/cityApi';
+import { useGetAdminBookingCustomerDetailsQuery } from '../../store/api/bookingCustomerDetailsApi';
+import DashboardCityFilter, { useDashboardCityFilter } from './DashboardCityFilter';
 import { LoadingSpinner } from '../../components/LoadingSpinner';
 import { exportToExcel, formatUsersForExport } from '../../utils/excelExport';
 
+// ── Helpers ─────────────────────────────────────────────────────────────────
+const STATUS_BADGE: Record<number, { label: string; cls: string }> = {
+  0: { label: 'Pending', cls: 'bg-yellow-100 text-yellow-700' },
+  1: { label: 'Confirmed', cls: 'bg-green-100 text-green-700' },
+  2: { label: 'Completed', cls: 'bg-blue-100 text-blue-700' },
+  3: { label: 'Cancelled', cls: 'bg-red-100 text-red-700' },
+};
+const inr = (n: number) => '₹' + (n || 0).toLocaleString('en-IN');
+const customerName = (u?: UserDto) => u?.name?.trim() || u?.userNumber || '—';
+const initials = (u: UserDto) =>
+  (u.name?.trim() ? u.name.trim().split(/\s+/).map((w) => w[0]).slice(0, 2).join('') : u.userNumber.slice(-2)).toUpperCase();
+const fmtDate = (d?: string) => {
+  if (!d) return '—';
+  const date = new Date(d);
+  return Number.isNaN(date.getTime()) ? String(d) : date.toLocaleDateString('en-IN', { day: '2-digit', month: 'short', year: 'numeric' });
+};
+
+interface CustomerStats { count: number; spent: number; bookings: BookingDto[]; }
+
 const UsersTab: React.FC = () => {
   const [userSearchQuery, setUserSearchQuery] = useState('');
+  const [activeFilter, setActiveFilter] = useState<'all' | 'with' | 'new'>('all');
+  const [selectedUser, setSelectedUser] = useState<UserDto | null>(null);
+  const [searchParams] = useSearchParams();
+  const highlightId = Number(searchParams.get('highlight')) || null;
+  const [flashId, setFlashId] = useState<number | null>(null);
+  const highlightRowRef = useRef<HTMLDivElement | null>(null);
 
   // ── API Calls ──────────────────────────────────────────────────────────
-  const { data: users = [], isLoading: usersLoading, refetch: refetchUsers } = useGetUsersQuery({ page: 1, size: 100 });
-  const [deleteUser] = useDeleteUserMutation();
+  const { data: users = [], isLoading: usersLoading } = useGetUsersQuery({ page: 1, size: 100 });
+  const { data: bookings = [] } = useGetBookingsQuery({ page: 1, size: 1000 });
+  const { data: cities = [] } = useGetCitiesQuery({ page: 1, size: 100 });
+  const { cityIdParam } = useDashboardCityFilter();
 
-  // ── Handlers ──────────────────────────────────────────────────────────
-  const handleDeleteUser = async (id: number) => {
-    if (!confirm('Are you sure you want to delete this customer?')) return;
-    try {
-      await deleteUser(id).unwrap();
-      toast.success('Customer deleted');
-      refetchUsers();
-    } catch { toast.error('Failed to delete customer'); }
-  };
+  // city id → name
+  const cityMap = useMemo(() => {
+    const m = new Map<number, string>();
+    cities.forEach((c) => m.set(c.id, c.name));
+    return m;
+  }, [cities]);
+
+  // userId → { count, spent, bookings }  (derived from the bookings list, no extra calls)
+  const statsMap = useMemo(() => {
+    const m = new Map<number, CustomerStats>();
+    bookings.forEach((b) => {
+      if (b.userId == null) return;
+      const s = m.get(b.userId) ?? { count: 0, spent: 0, bookings: [] };
+      s.count += 1;
+      if (b.status !== 3) s.spent += Number(b.totalAmount) || 0; // exclude cancelled from spend
+      s.bookings.push(b);
+      m.set(b.userId, s);
+    });
+    return m;
+  }, [bookings]);
+
+  const totals = useMemo(() => {
+    const withBookings = users.filter((u) => (statsMap.get(u.id)?.count ?? 0) > 0).length;
+    return { total: users.length, withBookings, fresh: users.length - withBookings };
+  }, [users, statsMap]);
+
+  // Flash + scroll to the row referenced by the ?highlight query param
+  useEffect(() => {
+    if (!highlightId || usersLoading) return;
+    setFlashId(highlightId);
+    const scrollTimer = setTimeout(() => {
+      highlightRowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }, 100);
+    const clearTimer = setTimeout(() => setFlashId(null), 3000);
+    return () => { clearTimeout(scrollTimer); clearTimeout(clearTimer); };
+  }, [highlightId, usersLoading]);
 
   // ── Filtered Data ──────────────────────────────────────────────────────
-  const filteredUsers = users.filter((u) =>
-    u.userNumber.toLowerCase().includes(userSearchQuery.toLowerCase())
-  );
+  const filteredUsers = useMemo(() => {
+    const q = userSearchQuery.trim().toLowerCase();
+    return users.filter((u) => {
+      if (cityIdParam != null && u.cityId !== cityIdParam) return false;
+      const count = statsMap.get(u.id)?.count ?? 0;
+      if (activeFilter === 'with' && count === 0) return false;
+      if (activeFilter === 'new' && count > 0) return false;
+      if (!q) return true;
+      return (
+        u.userNumber.toLowerCase().includes(q) ||
+        (u.name ?? '').toLowerCase().includes(q) ||
+        (u.email ?? '').toLowerCase().includes(q)
+      );
+    });
+  }, [users, userSearchQuery, activeFilter, statsMap, cityIdParam]);
 
   // ── Export Handler ─────────────────────────────────────────────────────
   const handleExportCustomers = () => {
-    if (users.length === 0) {
-      toast.error('No customers to export');
-      return;
-    }
-    const data = formatUsersForExport(users);
-    exportToExcel(data, 'Customers', 'Customers');
+    if (users.length === 0) { toast.error('No customers to export'); return; }
+    exportToExcel(formatUsersForExport(users), 'Customers', 'Customers');
     toast.success('Customers exported successfully');
   };
 
   return (
     <div>
+      {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
-        <h1 className="text-3xl font-bold text-gray-900">Customer Management</h1>
+        <div>
+          <h1 className="text-2xl lg:text-3xl font-extrabold text-gray-900">Customer Management</h1>
+          <p className="text-sm text-gray-500 mt-1">All registered customers, their activity and spend</p>
+        </div>
         <button
           onClick={handleExportCustomers}
-          className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition text-sm font-medium"
+          className="flex items-center gap-2 px-4 py-2.5 bg-white border border-gray-200 text-gray-700 rounded-xl hover:bg-gray-50 transition text-sm font-semibold shadow-sm"
         >
-          <Download className="w-4 h-4" />
-          Export Customers
+          <Download className="w-4 h-4 text-green-600" /> Export Customers
         </button>
       </div>
-      <div className="flex gap-4 mb-6">
-        <div className="flex-1 relative">
-          <Search className="w-5 h-5 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
-          <input
-            type="text"
-            placeholder="Search by phone number..."
-            value={userSearchQuery}
-            onChange={(e) => setUserSearchQuery(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none"
-          />
+
+      {/* Stat strip */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
+        <StatCard icon={<UsersIcon className="w-5 h-5" />} tone="bg-primary-50 text-primary-600" label="Total" value={String(totals.total)} />
+        <StatCard icon={<UserCheck className="w-5 h-5" />} tone="bg-blue-50 text-blue-600" label="With Bookings" value={String(totals.withBookings)} />
+        <StatCard icon={<UserPlus className="w-5 h-5" />} tone="bg-amber-50 text-amber-600" label="New (no booking)" value={String(totals.fresh)} />
+      </div>
+
+      {/* Toolbar */}
+      <div className="bg-white rounded-2xl p-4 shadow-sm border border-gray-100 mb-5">
+        <div className="flex flex-col lg:flex-row lg:items-center gap-3">
+          <div className="relative flex-1">
+            <Search className="w-4 h-4 absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Search by name, phone or email..."
+              value={userSearchQuery}
+              onChange={(e) => setUserSearchQuery(e.target.value)}
+              className="w-full pl-10 pr-4 py-2.5 bg-gray-50 border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-primary-200 focus:border-primary-500"
+            />
+          </div>
+          <DashboardCityFilter />
+          <div className="flex items-center gap-1 bg-gray-100 p-1 rounded-xl">
+            {([['all', 'All'], ['with', 'With bookings'], ['new', 'New']] as const).map(([val, lbl]) => (
+              <button
+                key={val}
+                onClick={() => setActiveFilter(val)}
+                className={`px-3.5 py-1.5 rounded-lg text-sm whitespace-nowrap transition ${
+                  activeFilter === val ? 'bg-white text-primary-700 font-semibold shadow-sm' : 'text-gray-500 hover:text-gray-800 font-medium'
+                }`}
+              >
+                {lbl}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
+
       {usersLoading ? <LoadingSpinner /> : (
-        <div className="bg-white rounded-xl shadow-md overflow-hidden">
-          <table className="w-full">
-            <thead className="bg-gray-50">
-              <tr>
-                {['Customer ID', 'Phone Number', 'City ID', 'Actions'].map((h) => (
-                  <th key={h} className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase">{h}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {filteredUsers.map((user) => (
-                <tr key={user.id} className="hover:bg-gray-50 transition">
-                  <td className="px-6 py-4 font-medium text-gray-900">#{user.id}</td>
-                  <td className="px-6 py-4 text-sm text-gray-900">
-                    <div className="flex items-center">
-                      <div className="w-8 h-8 bg-primary-100 rounded-full flex items-center justify-center mr-3 text-primary-600 font-semibold text-sm">
-                        {user.userNumber.slice(-2)}
+        <>
+          {/* Column header (desktop) */}
+          <div className="hidden lg:grid px-5 mb-2 gap-4 items-center text-[11px] font-bold uppercase tracking-wide text-gray-400"
+               style={{ gridTemplateColumns: '1.6fr 1.2fr 1fr 0.8fr 0.8fr 80px' }}>
+            <span>Customer</span><span>Email</span><span>City</span><span>Bookings</span><span className="text-right">Total Spent</span><span className="text-right">Action</span>
+          </div>
+
+          <div className="space-y-2.5">
+            {filteredUsers.map((user) => {
+              const stats = statsMap.get(user.id);
+              const count = stats?.count ?? 0;
+              return (
+                <div
+                  key={user.id}
+                  ref={user.id === highlightId ? highlightRowRef : undefined}
+                  className={`bg-white rounded-2xl border border-gray-100 shadow-sm hover:shadow-md transition ${flashId === user.id ? 'bg-yellow-100 ring-2 ring-yellow-400' : ''}`}
+                >
+                  <div className="px-5 py-4 grid gap-3 lg:gap-4 items-center grid-cols-1 lg:[grid-template-columns:1.6fr_1.2fr_1fr_0.8fr_0.8fr_80px]">
+                    {/* Customer */}
+                    <div className="flex items-center gap-3">
+                      <div className={`w-11 h-11 rounded-xl flex items-center justify-center font-bold shrink-0 ${count ? 'bg-primary-100 text-primary-700' : 'bg-gray-100 text-gray-400'}`}>
+                        {initials(user)}
                       </div>
-                      {user.userNumber}
+                      <div className="min-w-0">
+                        <p className="font-bold text-gray-900 truncate">{customerName(user)}</p>
+                        <p className="text-xs text-gray-500 flex items-center gap-1"><Phone className="w-3 h-3" />{user.userNumber}</p>
+                      </div>
                     </div>
-                  </td>
-                  <td className="px-6 py-4 text-sm text-gray-600">{user.cityId ?? 'N/A'}</td>
-                  <td className="px-6 py-4">
-                    <button onClick={() => handleDeleteUser(user.id)} className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition">
-                      <Trash2 className="w-4 h-4" />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-              {filteredUsers.length === 0 && (
-                <tr><td colSpan={4} className="px-6 py-12 text-center text-gray-500">No customers found</td></tr>
-              )}
-            </tbody>
-          </table>
-        </div>
+                    {/* Email */}
+                    <div className="min-w-0">
+                      <p className="lg:hidden text-[11px] uppercase text-gray-400 font-semibold">Email</p>
+                      <p className="text-sm text-gray-700 truncate">{user.email || <span className="text-gray-300">—</span>}</p>
+                    </div>
+                    {/* City */}
+                    <div>
+                      <p className="lg:hidden text-[11px] uppercase text-gray-400 font-semibold">City</p>
+                      <p className="text-sm text-gray-700">{user.cityId != null ? (cityMap.get(user.cityId) ?? `City #${user.cityId}`) : '—'}</p>
+                    </div>
+                    {/* Bookings */}
+                    <div>
+                      <p className="lg:hidden text-[11px] uppercase text-gray-400 font-semibold">Bookings</p>
+                      {count
+                        ? <span className="px-2 py-0.5 rounded-full text-xs font-semibold bg-primary-50 text-primary-700">{count} booking{count > 1 ? 's' : ''}</span>
+                        : <span className="px-2 py-0.5 rounded-full text-xs font-semibold bg-gray-100 text-gray-400">New</span>}
+                    </div>
+                    {/* Spent */}
+                    <div className="lg:text-right">
+                      <p className="lg:hidden text-[11px] uppercase text-gray-400 font-semibold">Total Spent</p>
+                      <p className="font-bold text-gray-900">{inr(stats?.spent ?? 0)}</p>
+                    </div>
+                    {/* Action */}
+                    <div className="flex lg:justify-end">
+                      <button
+                        onClick={() => setSelectedUser(user)}
+                        className="w-9 h-9 flex items-center justify-center rounded-lg bg-gray-100 text-gray-600 hover:bg-gray-200 transition"
+                        title="View customer profile"
+                      >
+                        <Eye className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+            {filteredUsers.length === 0 && (
+              <div className="bg-white rounded-2xl border border-gray-100 shadow-sm px-6 py-16 text-center text-gray-500">
+                No customers found
+              </div>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Profile drawer */}
+      {selectedUser && (
+        <CustomerDrawer
+          user={selectedUser}
+          stats={statsMap.get(selectedUser.id)}
+          cityName={selectedUser.cityId != null ? cityMap.get(selectedUser.cityId) : undefined}
+          onClose={() => setSelectedUser(null)}
+        />
       )}
     </div>
   );
 };
+
+// ── Stat card ───────────────────────────────────────────────────────────────
+const StatCard: React.FC<{ icon: React.ReactNode; tone: string; label: string; value: string }> = ({ icon, tone, label, value }) => (
+  <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-4">
+    <div className="flex items-center gap-3">
+      <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${tone}`}>{icon}</div>
+      <div>
+        <p className="text-xs text-gray-400 font-semibold uppercase">{label}</p>
+        <p className="text-xl font-extrabold text-gray-900">{value}</p>
+      </div>
+    </div>
+  </div>
+);
+
+// ── Customer drawer ───────────────────────────────────────────────────────────
+interface DrawerProps {
+  user: UserDto;
+  stats?: CustomerStats;
+  cityName?: string;
+  onClose: () => void;
+}
+
+const CustomerDrawer: React.FC<DrawerProps> = ({ user, stats, cityName, onClose }) => {
+  const history = useMemo(
+    () => [...(stats?.bookings ?? [])].sort((a, b) => (b.id ?? 0) - (a.id ?? 0)),
+    [stats],
+  );
+  // Latest booking holds the customer's submitted form data (DL, address, etc.)
+  const latestBookingId = history[0]?.id;
+  const { data: form } = useGetAdminBookingCustomerDetailsQuery(latestBookingId as number, { skip: latestBookingId == null });
+
+  return (
+    <>
+      <div onClick={onClose} className="fixed inset-0 bg-black/40 z-40" />
+      <div className="fixed top-0 right-0 h-full w-full max-w-md bg-gray-50 shadow-2xl z-50 overflow-y-auto">
+        {/* Header */}
+        <div className="sticky top-0 bg-white border-b border-gray-100 px-5 py-4 flex items-center justify-between z-10">
+          <div>
+            <p className="text-xs text-gray-400 font-semibold uppercase tracking-wide">Customer Profile</p>
+            <h3 className="text-lg font-extrabold text-gray-900">{customerName(user)}</h3>
+          </div>
+          <button onClick={onClose} className="w-9 h-9 rounded-lg hover:bg-gray-100 text-gray-500 flex items-center justify-center">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          {/* Profile head */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-4 flex items-center gap-4">
+            <div className="w-16 h-16 rounded-2xl bg-primary-100 text-primary-700 flex items-center justify-center text-xl font-extrabold">{initials(user)}</div>
+            <div className="min-w-0">
+              <p className="font-extrabold text-gray-900 text-lg truncate">{customerName(user)}</p>
+              <p className="text-sm text-gray-500">Customer #{user.id}</p>
+            </div>
+          </div>
+
+          {/* Contact */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-4">
+            <h4 className="text-xs font-bold uppercase text-gray-400 tracking-wide mb-3">Contact</h4>
+            <div className="space-y-3 text-sm">
+              <div className="flex items-center gap-3"><Phone className="w-4 h-4 text-gray-400" /><span className="font-medium">{user.userNumber}</span></div>
+              <div className="flex items-center gap-3"><Mail className="w-4 h-4 text-gray-400" /><span className="font-medium">{user.email || '—'}</span></div>
+              <div className="flex items-center gap-3"><MapPin className="w-4 h-4 text-gray-400" /><span className="font-medium">{cityName ?? (user.cityId != null ? `City #${user.cityId}` : '—')}</span></div>
+            </div>
+          </div>
+
+          {/* Stats */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="bg-white rounded-2xl border border-gray-100 p-4 text-center">
+              <p className="text-2xl font-extrabold text-gray-900">{stats?.count ?? 0}</p>
+              <p className="text-xs text-gray-400 font-semibold uppercase mt-1">Bookings</p>
+            </div>
+            <div className="bg-white rounded-2xl border border-gray-100 p-4 text-center">
+              <p className="text-2xl font-extrabold text-gray-900">{inr(stats?.spent ?? 0)}</p>
+              <p className="text-xs text-gray-400 font-semibold uppercase mt-1">Total Spent</p>
+            </div>
+          </div>
+
+          {/* Submitted details (from latest booking form) */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-4">
+            <h4 className="text-xs font-bold uppercase text-gray-400 tracking-wide mb-3 flex items-center gap-2"><IdCard className="w-4 h-4" /> Submitted Details</h4>
+            {!form ? (
+              <p className="text-sm text-gray-400">No submitted details on record.</p>
+            ) : (
+              <div className="space-y-3 text-sm">
+                <DetailRow label="Driving License No." value={form.drivingLicenseNo} />
+                <DetailRow label="Address" value={form.guestAddress} />
+                <div className="grid grid-cols-2 gap-x-4">
+                  <DetailRow label="Hotel Name" value={form.hotelName} />
+                  <DetailRow label="Hotel Address" value={form.hotelAddress} />
+                </div>
+                <DetailRow label="F&F Contact" value={form.friendFamilyContactNumber} />
+              </div>
+            )}
+          </div>
+
+          {/* Booking history */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-4">
+            <h4 className="text-xs font-bold uppercase text-gray-400 tracking-wide mb-3">Booking History</h4>
+            {history.length === 0 ? (
+              <p className="text-sm text-gray-400">No bookings yet.</p>
+            ) : (
+              <div className="space-y-2 text-sm">
+                {history.map((b) => {
+                  const st = STATUS_BADGE[b.status] ?? STATUS_BADGE[0];
+                  return (
+                    <div key={b.id} className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0">
+                      <div className="min-w-0">
+                        <p className="font-semibold text-gray-800 flex items-center gap-1.5">
+                          <Bike className="w-3.5 h-3.5 text-gray-400" />#{b.id} · <span className="truncate">{b.vehicleName || `Vehicle #${b.vehicleId}`}</span>
+                        </p>
+                        <p className="text-xs text-gray-400 mt-0.5">{fmtDate(b.bookingStartDate)} · {inr(Number(b.totalAmount) || 0)}</p>
+                      </div>
+                      <span className={`px-2 py-0.5 rounded-full text-xs font-semibold shrink-0 ${st.cls}`}>{st.label}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+const DetailRow: React.FC<{ label: string; value?: React.ReactNode }> = ({ label, value }) => (
+  <div>
+    <p className="text-gray-400 text-xs">{label}</p>
+    <p className="font-medium text-gray-800 break-words">{value || '—'}</p>
+  </div>
+);
 
 export default UsersTab;

--- a/src/components/admin/VehiclesTab.tsx
+++ b/src/components/admin/VehiclesTab.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   Plus, Edit, Trash2, Search, CheckCircle, XCircle, Clock,
   Image, MapPin, X, Save, Loader2, Star, Eye, Package, FileText, Shield, Ghost,
@@ -57,6 +58,10 @@ interface VehicleDraft {
 
 const VehiclesTab: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
+  const [searchParams] = useSearchParams();
+  const highlightId = Number(searchParams.get('highlight')) || null;
+  const [flashId, setFlashId] = useState<number | null>(null);
+  const highlightRowRef = useRef<HTMLTableRowElement | null>(null);
   const [showVehicleModal, setShowVehicleModal] = useState(false);
   const [editingVehicle, setEditingVehicle] = useState<VehicleDto | null>(null);
   const [vehicleForm, setVehicleForm] = useState<Omit<VehicleDto, 'id'>>(EMPTY_VEHICLE);
@@ -148,6 +153,17 @@ const VehiclesTab: React.FC = () => {
   const { data: vehicles = [], isLoading: vehiclesLoading, refetch: refetchVehicles } = useGetVehiclesForAdminQuery(
     { cityId: cityIdParam }
   );
+
+  // Flash + scroll to the row referenced by the ?highlight query param
+  useEffect(() => {
+    if (!highlightId || vehiclesLoading) return;
+    setFlashId(highlightId);
+    const scrollTimer = setTimeout(() => {
+      highlightRowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }, 100);
+    const clearTimer = setTimeout(() => setFlashId(null), 3000);
+    return () => { clearTimeout(scrollTimer); clearTimeout(clearTimer); };
+  }, [highlightId, vehiclesLoading]);
   const { data: cities = [] } = useGetCitiesQuery({ page: 1, size: 100 });
   const { data: vehiclePackages = [] } = useGetVehiclePackagesQuery();
 
@@ -383,7 +399,11 @@ const VehiclesTab: React.FC = () => {
               </thead>
               <tbody className="divide-y divide-gray-200">
                 {filteredVehicles.map((vehicle) => (
-                  <tr key={vehicle.id} className="hover:bg-gray-50 transition">
+                  <tr
+                    key={vehicle.id}
+                    ref={vehicle.id === highlightId ? highlightRowRef : undefined}
+                    className={`transition-colors duration-700 ${flashId === vehicle.id ? 'bg-yellow-100 ring-2 ring-yellow-400' : 'hover:bg-gray-50'}`}
+                  >
                     <td className="px-4 lg:px-6 py-3 lg:py-4">
                       <p className="font-medium text-gray-900 text-sm lg:text-base">{vehicle.name}</p>
                       <p className="text-xs text-gray-500">{vehicle.model}</p>

--- a/src/config/api.config.ts
+++ b/src/config/api.config.ts
@@ -32,7 +32,6 @@ export const API_ENDPOINTS = {
   BOOKINGS: '/Bookings',
   BOOKING_BY_ID: (id: number) => `/Bookings/${id}`,
   BOOKINGS_BY_USER: (userId: number) => `/Bookings/user/${userId}`,
-
   // Locations
   LOCATIONS: '/Locations',
   LOCATIONS_BY_CITY: (cityId: number) => `/Locations/city/${cityId}`,

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -12,7 +12,7 @@ import { Button } from '../components/ui/button';
 import { useAppSelector, useAppDispatch } from '../store/hooks';
 import { setCredentials } from '../store/slices/authSlice';
 import { logout } from '../store/slices/authSlice';
-import { useGetBookingsByUserIdQuery } from '../store/api/bookingApi';
+import { useGetBookingsByUserIdQuery, useCancelBookingMutation } from '../store/api/bookingApi';
 import type { BookingDto } from '../store/api/bookingApi';
 import {
   useDeleteMyDocumentMutation,
@@ -1447,6 +1447,7 @@ export default function ProfilePage() {
     isError: isBookingsError,
     refetch: refetchBookings,
   } = useGetBookingsByUserIdQuery(user?.id ?? 0, { skip: !user?.id });
+  const [cancelBooking, { isLoading: isCancellingBooking }] = useCancelBookingMutation();
 
   const drivingLicenseDocument = getLatestProfileDocument(userDocuments, 'driving_license');
   const aadhaarDocument = getLatestProfileDocument(userDocuments, 'aadhaar');
@@ -1518,16 +1519,38 @@ export default function ProfilePage() {
     const timeRemaining = getPendingTimeRemaining(booking.createdAt);
 
     if (timeRemaining.expired) {
-      toast.error('This booking has expired. Please create a new booking.');
-      refetchBookings();
-      if (selectedBooking?.id === booking.id) {
-        setSelectedBooking(null);
-      }
+      // Free the vehicle immediately by cancelling the expired pending booking,
+      // then send the user to rebook instead of leaving the vehicle blocked.
+      void handleCancelPendingBooking(booking, { silent: true }).then(() => {
+        toast.error('This booking expired and was released. Please book again.');
+      });
       return;
     }
 
     setSelectedBooking(null);
     setPaymentBooking(booking);
+  };
+
+  const handleCancelPendingBooking = async (
+    booking: BookingDto,
+    opts?: { silent?: boolean }
+  ) => {
+    if (booking.id == null) return;
+    try {
+      await cancelBooking(booking.id).unwrap();
+      if (selectedBooking?.id === booking.id) {
+        setSelectedBooking(null);
+      }
+      await refetchBookings();
+      if (!opts?.silent) {
+        toast.success('Booking cancelled. The vehicle is now available to rebook.');
+      }
+    } catch (err: any) {
+      await refetchBookings();
+      if (!opts?.silent) {
+        toast.error(err?.data?.error ?? 'Could not cancel booking. Please try again.');
+      }
+    }
   };
 
   const handlePaymentSuccess = async () => {
@@ -1922,6 +1945,13 @@ export default function ProfilePage() {
                                 className="flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-semibold text-amber-600 bg-amber-50 hover:bg-amber-100 rounded-lg transition"
                               >
                                 <CreditCard className="w-3.5 h-3.5" /> Pay
+                              </button>
+                              <button
+                                onClick={() => handleCancelPendingBooking(booking)}
+                                disabled={isCancellingBooking}
+                                className="flex items-center justify-center gap-1.5 px-3 py-2 text-xs font-semibold text-red-600 bg-red-50 hover:bg-red-100 rounded-lg transition disabled:opacity-50"
+                              >
+                                <XCircle className="w-3.5 h-3.5" /> Cancel
                               </button>
                             </>
                           )}

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { useAppSelector } from '../store/hooks';
+import { useAppSelector, useAppDispatch } from '../store/hooks';
 import { isAdminApp } from '../utils/appType';
+import { setCredentials } from '../store/slices/authSlice';
+import { API_CONFIG } from '../config/api.config';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -15,18 +17,101 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 }) => {
   const { user, isAuthenticated } = useAppSelector((state) => state.auth);
   const { hasChangedPassword } = useAppSelector((state) => state.adminAuth);
+  const dispatch = useAppDispatch();
   const location = useLocation();
 
-  // Not authenticated → redirect to login
-  if (!isAuthenticated || !user) {
-  return (
-    <Navigate
-      to="/login"
-      state={{ from: location }}
-      replace
-    />
+  const hasUser = isAuthenticated && !!user;
+
+  // When there is no user in memory we may still have a valid HttpOnly refresh
+  // cookie (e.g. access token expired, localStorage cleared, or a transient
+  // logout). Attempt a silent session restore before redirecting to login so a
+  // valid session isn't thrown away. The refresh endpoint's 401 is the source
+  // of truth, not the absence of localStorage.
+  const [restoreState, setRestoreState] = useState<'restoring' | 'failed'>(
+    'restoring'
   );
-}
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (hasUser || attempted.current) return;
+    attempted.current = true;
+
+    const base = API_CONFIG.BASE_URL.replace(/\/$/, '');
+    (async () => {
+      try {
+        const res = await fetch(`${base}/Auth/refresh`, {
+          method: 'POST',
+          credentials: 'include',
+        });
+        if (!res.ok) {
+          setRestoreState('failed');
+          return;
+        }
+        const data = await res.json();
+        if (data?.success && data.userData) {
+          const resolvedUserType =
+            (data.userType?.toLowerCase() as 'user' | 'admin' | 'superadmin') ||
+            'user';
+          dispatch(
+            setCredentials({
+              user: {
+                id: data.userData.id,
+                name: data.userData.username || data.userData.name || '',
+                phone: data.userData.userNumber || data.userData.number || '',
+                email: data.userData.email,
+                dateOfBirth: data.userData.dateOfBirth,
+                anniversaryDate: data.userData.anniversaryDate,
+                cityId: data.userData.cityId,
+                userType: resolvedUserType,
+              },
+              token: data.token,
+              refreshToken: data.refreshToken,
+            })
+          );
+        } else {
+          setRestoreState('failed');
+        }
+      } catch {
+        setRestoreState('failed');
+      }
+    })();
+  }, [hasUser, dispatch]);
+
+  // Not authenticated → try to restore, then redirect to login if that fails.
+  if (!hasUser) {
+    if (restoreState === 'restoring') {
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '100vh',
+          }}
+        >
+          <div
+            style={{
+              width: 40,
+              height: 40,
+              border: '3px solid #e5e7eb',
+              borderTopColor: '#2563eb',
+              borderRadius: '50%',
+              animation: 'spin 0.8s linear infinite',
+            }}
+          />
+          <style>{'@keyframes spin{to{transform:rotate(360deg)}}'}</style>
+        </div>
+      );
+    }
+
+    return (
+      <Navigate
+        to="/login"
+        state={{ from: location }}
+        replace
+      />
+    );
+  }
 
   // Role check - if user doesn't have required role
   if (allowedRoles && !allowedRoles.includes(user.userType as any)) {

--- a/src/store/api/bookingApi.ts
+++ b/src/store/api/bookingApi.ts
@@ -100,6 +100,13 @@ export const bookingApi = createApi({
       }),
       invalidatesTags: ['Booking'],
     }),
+    superAdminCancelBooking: builder.mutation<{ message: string }, number>({
+      query: (id) => ({
+        url: `${API_ENDPOINTS.BOOKINGS}/${id}/admin-cancel`,
+        method: 'POST',
+      }),
+      invalidatesTags: ['Booking'],
+    }),
   }),
 });
 
@@ -111,4 +118,5 @@ export const {
   useUpdateBookingMutation,
   useDeleteBookingMutation,
   useCancelBookingMutation,
+  useSuperAdminCancelBookingMutation,
 } = bookingApi;

--- a/src/store/api/bookingCustomerDetailsApi.ts
+++ b/src/store/api/bookingCustomerDetailsApi.ts
@@ -33,6 +33,13 @@ export const bookingCustomerDetailsApi = createApi({
                 { type: 'BookingCustomerDetails', id: bookingId },
             ],
         }),
+        // Admin/SuperAdmin: view customer details for ANY booking
+        getAdminBookingCustomerDetails: builder.query<UserBookingDetailsResponse, number>({
+            query: (bookingId) => `/admin/bookings/${bookingId}/customer-details`,
+            providesTags: (_result, _error, bookingId) => [
+                { type: 'BookingCustomerDetails', id: bookingId },
+            ],
+        }),
         upsertBookingCustomerDetails: builder.mutation<
             UserBookingDetailsResponse,
             { bookingId: number; data: UserBookingDetailsRequest }
@@ -51,5 +58,6 @@ export const bookingCustomerDetailsApi = createApi({
 
 export const {
     useGetBookingCustomerDetailsQuery,
+    useGetAdminBookingCustomerDetailsQuery,
     useUpsertBookingCustomerDetailsMutation,
 } = bookingCustomerDetailsApi;

--- a/src/store/api/offlineBookingApi.ts
+++ b/src/store/api/offlineBookingApi.ts
@@ -1,7 +1,8 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import type { BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolkit/query';
+import type { BaseQueryApi, BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { API_CONFIG } from '../../config/api.config';
-import { staffLogout } from '../slices/staffAuthSlice';
+import { setStaffCredentials, staffLogout, type StaffUser } from '../slices/staffAuthSlice';
+import { staffRefreshMutex } from './staffApi';
 
 const getOfflineBookingToken = () => (
   localStorage.getItem('staff_token')
@@ -73,24 +74,57 @@ const baseQueryWithStaff401Logout: BaseQueryFn<string | FetchArgs, unknown, Fetc
   api,
   extraOptions
 ) => {
-  const result = await rawBaseQuery(args, api, extraOptions);
+  // Wait for any in-flight refresh (shared with staffApi) before firing the request.
+  await staffRefreshMutex.waitForUnlock();
+  let result = await rawBaseQuery(args, api, extraOptions);
 
-  // If this call is being made under a staff session and backend returns 401,
-  // force staff logout to match staff portal behavior.
+  // Only attempt recovery for staff sessions.
   if (result.error && result.error.status === 401 && localStorage.getItem('staff_token')) {
-    api.dispatch(staffLogout());
-    localStorage.removeItem('staff_token');
-    localStorage.removeItem('staff_refresh_token');
-    localStorage.removeItem('staff');
-    localStorage.removeItem('staffId');
+    if (!staffRefreshMutex.isLocked()) {
+      // We win the lock: perform a single refresh, then retry the original request.
+      const release = await staffRefreshMutex.acquire();
+      try {
+        const refreshResult = await rawBaseQuery(
+          { url: '/staff/auth/refresh', method: 'POST' },
+          api,
+          extraOptions
+        );
 
-    if (window.location.pathname !== '/login') {
-      window.location.href = '/login';
+        const data = refreshResult.data as
+          | { success?: boolean; token?: string; userData?: StaffUser }
+          | undefined;
+
+        if (data?.success && data.token && data.userData) {
+          localStorage.setItem('staff_token', data.token);
+          api.dispatch(setStaffCredentials({ staff: data.userData }));
+          result = await rawBaseQuery(args, api, extraOptions);
+        } else {
+          forceStaffLogout(api);
+        }
+      } finally {
+        release();
+      }
+    } else {
+      // A refresh is already in progress elsewhere: wait for it, then retry once.
+      await staffRefreshMutex.waitForUnlock();
+      result = await rawBaseQuery(args, api, extraOptions);
     }
   }
 
   return result;
 };
+
+function forceStaffLogout(api: BaseQueryApi) {
+  api.dispatch(staffLogout());
+  localStorage.removeItem('staff_token');
+  localStorage.removeItem('staff_refresh_token');
+  localStorage.removeItem('staff');
+  localStorage.removeItem('staffId');
+
+  if (window.location.pathname !== '/login') {
+    window.location.href = '/login';
+  }
+}
 
 export const offlineBookingApi = createApi({
   reducerPath: 'offlineBookingApi',

--- a/src/store/api/staffApi.ts
+++ b/src/store/api/staffApi.ts
@@ -21,6 +21,10 @@ export interface StaffLoginResponse {
 
 const mutex = new Mutex();
 
+// Shared so other staff-scoped API slices (e.g. offlineBookingApi) serialize refreshes
+// against the SAME lock and don't trigger concurrent refresh races.
+export const staffRefreshMutex = mutex;
+
 export interface StaffProfileDto {
     id: number;
     username: string;


### PR DESCRIPTION
- Redesign admin Bookings, Customers (Users), and Vehicles tabs with a unified card layout, status filters, detail drawers, and clickable customer/vehicle links with row highlight on navigation.
- Add geofence 'Auto-fill City' that pulls the real city (municipal) boundary from OpenStreetMap using the city's state for accuracy; polygon is editable for manual fine-tuning, with manual draw still available.
- Let users cancel an expired/pending booking from the profile page to release the vehicle for rebooking immediately.
- Harden ProtectedRoute with a silent session refresh before redirecting to login.