### PR TITLE
fix: reliable photo/video capture on mobile

### DIFF
--- a/src/components/admin/OfflineBookingForm.tsx
+++ b/src/components/admin/OfflineBookingForm.tsx
@@ -231,6 +231,7 @@ const OfflineBookingForm: React.FC = () => {
   const [otherImages, setOtherImages] = useState<File[]>([]);
   const [otherVideo, setOtherVideo] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const nativeCameraInputRef = useRef<HTMLInputElement>(null);
   const videoPreviewRef = useRef<HTMLVideoElement>(null);
   const cameraStreamRef = useRef<MediaStream | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -587,6 +588,19 @@ const OfflineBookingForm: React.FC = () => {
     if (videoPreviewRef.current) {
       videoPreviewRef.current.srcObject = null;
     }
+  };
+
+  // Live preview (getUserMedia/MediaRecorder) needs a secure context and a full browser, and
+  // iOS Safari can't record WebM. On http://, in-app webviews, or unsupported browsers fall
+  // back to the native device camera via <input capture>.
+  const canUseLiveCamera =
+    typeof navigator !== 'undefined' &&
+    !!navigator.mediaDevices?.getUserMedia &&
+    typeof window !== 'undefined' &&
+    window.isSecureContext;
+
+  const openNativeCamera = () => {
+    nativeCameraInputRef.current?.click();
   };
 
   const startCameraStream = async () => {
@@ -1652,7 +1666,12 @@ const OfflineBookingForm: React.FC = () => {
                     type="button"
                     onClick={() => {
                       setSelectedDocumentFile(null);
-                      setDocumentInputMode('camera');
+                      setCameraError(null);
+                      if (canUseLiveCamera) {
+                        setDocumentInputMode('camera');
+                      } else {
+                        openNativeCamera();
+                      }
                     }}
                     className={`px-3 py-2 rounded-lg border text-sm font-medium transition ${documentInputMode === 'camera'
                       ? 'border-primary-600 bg-primary-50 text-primary-700'
@@ -1690,25 +1709,54 @@ const OfflineBookingForm: React.FC = () => {
                     className="hidden"
                   />
 
+                  <input
+                    ref={nativeCameraInputRef}
+                    type="file"
+                    accept={isVehicleVideoDocumentType ? 'video/*' : selectedDocumentType === 'other' ? 'image/*,video/*' : 'image/*'}
+                    capture="environment"
+                    onChange={(e) => {
+                      const files = Array.from(e.target.files || []);
+                      if (selectedDocumentType === 'other') {
+                        addOtherFiles(files);
+                      } else {
+                        setSelectedSingleDocumentFile(files[0] || null);
+                      }
+                      if (nativeCameraInputRef.current) {
+                        nativeCameraInputRef.current.value = '';
+                      }
+                    }}
+                    className="hidden"
+                  />
+
                   {documentInputMode === 'camera' ? (
                     <div className="w-full space-y-3 cursor-default" onClick={(e) => e.stopPropagation()}>
-                      <div className="overflow-hidden rounded-lg bg-gray-900 aspect-[4/3] flex items-center justify-center">
+                      <div className="relative overflow-hidden rounded-lg bg-gray-900 aspect-[4/3] flex items-center justify-center">
+                        <video
+                          ref={videoPreviewRef}
+                          autoPlay
+                          playsInline
+                          muted
+                          className="h-full w-full object-cover"
+                        />
                         {cameraError ? (
-                          <p className="px-4 text-center text-sm text-white/85">{cameraError}</p>
+                          <div className="absolute inset-0 flex items-center justify-center bg-gray-900 px-4 text-center">
+                            <div className="space-y-2">
+                              <p className="text-sm text-white/85">{cameraError}</p>
+                              <button
+                                type="button"
+                                onClick={openNativeCamera}
+                                className="px-3 py-1.5 bg-white/15 text-white text-sm rounded-lg hover:bg-white/25 transition"
+                              >
+                                Use device camera
+                              </button>
+                            </div>
+                          </div>
                         ) : isCameraStarting ? (
-                          <div className="flex items-center text-sm text-white/85">
+                          <div className="absolute inset-0 flex items-center justify-center bg-gray-900 text-sm text-white/85">
                             <Loader2 className="w-4 h-4 mr-2 animate-spin" />
                             Starting camera...
                           </div>
-                        ) : (
-                          <video
-                            ref={videoPreviewRef}
-                            autoPlay
-                            playsInline
-                            muted
-                            className="h-full w-full object-cover"
-                          />
-                        )}
+                        ) : null}
                       </div>
                       <div className="flex gap-2 flex-wrap">
                         {!isVehicleVideoDocumentType && (

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -172,8 +172,22 @@ function ProfileDocumentUploadModal({
   const [isCameraStarting, setIsCameraStarting] = useState(false);
   const [uploadMyDocument, { isLoading: isUploading }] = useUploadMyDocumentMutation();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const nativeCameraInputRef = useRef<HTMLInputElement>(null);
   const videoPreviewRef = useRef<HTMLVideoElement>(null);
   const cameraStreamRef = useRef<MediaStream | null>(null);
+
+  // Live preview (getUserMedia) only works in a secure context (HTTPS/localhost) and full
+  // browsers. On http://, in-app webviews, or unsupported browsers we fall back to the native
+  // device camera via <input capture>.
+  const canUseLiveCamera =
+    typeof navigator !== 'undefined' &&
+    !!navigator.mediaDevices?.getUserMedia &&
+    typeof window !== 'undefined' &&
+    window.isSecureContext;
+
+  const openNativeCamera = () => {
+    nativeCameraInputRef.current?.click();
+  };
 
   const stopCameraStream = () => {
     if (!cameraStreamRef.current) {
@@ -342,7 +356,12 @@ function ProfileDocumentUploadModal({
               type="button"
               onClick={() => {
                 setSelectedFile(null);
-                setInputMode('camera');
+                setCameraError(null);
+                if (canUseLiveCamera) {
+                  setInputMode('camera');
+                } else {
+                  openNativeCamera();
+                }
               }}
               className={`px-3 py-2 rounded-lg border text-sm font-medium transition ${inputMode === 'camera'
                 ? 'border-primary-600 bg-primary-50 text-primary-700'
@@ -353,25 +372,53 @@ function ProfileDocumentUploadModal({
             </button>
           </div>
 
+          <input
+            ref={nativeCameraInputRef}
+            type="file"
+            accept="image/*"
+            capture="environment"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0] || null;
+              if (file) {
+                setSelectedFile(file);
+                setInputMode('upload');
+              }
+              if (nativeCameraInputRef.current) {
+                nativeCameraInputRef.current.value = '';
+              }
+            }}
+          />
+
           {inputMode === 'camera' ? (
             <div className="space-y-3 rounded-xl border border-gray-200 p-3">
-              <div className="overflow-hidden rounded-lg bg-gray-900 aspect-[4/3] flex items-center justify-center">
+              <div className="relative overflow-hidden rounded-lg bg-gray-900 aspect-[4/3] flex items-center justify-center">
+                <video
+                  ref={videoPreviewRef}
+                  autoPlay
+                  playsInline
+                  muted
+                  className="h-full w-full object-cover"
+                />
                 {cameraError ? (
-                  <p className="px-4 text-center text-sm text-white/85">{cameraError}</p>
+                  <div className="absolute inset-0 flex items-center justify-center bg-gray-900 px-4 text-center">
+                    <div className="space-y-2">
+                      <p className="text-sm text-white/85">{cameraError}</p>
+                      <button
+                        type="button"
+                        onClick={openNativeCamera}
+                        className="px-3 py-1.5 bg-white/15 text-white text-sm rounded-lg hover:bg-white/25 transition"
+                      >
+                        Use device camera
+                      </button>
+                    </div>
+                  </div>
                 ) : isCameraStarting ? (
-                  <div className="flex items-center text-sm text-white/85">
+                  <div className="absolute inset-0 flex items-center justify-center bg-gray-900 text-sm text-white/85">
                     <Loader2 className="w-4 h-4 mr-2 animate-spin" />
                     Starting camera...
                   </div>
-                ) : (
-                  <video
-                    ref={videoPreviewRef}
-                    autoPlay
-                    playsInline
-                    muted
-                    className="h-full w-full object-cover"
-                  />
-                )}
+                ) : null}
               </div>
               <div className="flex gap-2 flex-wrap">
                 <button

--- a/src/pages/staff/StaffBookingsPage.tsx
+++ b/src/pages/staff/StaffBookingsPage.tsx
@@ -387,6 +387,7 @@ const BookingDetail: React.FC<BookingDetailProps> = ({ bookingId, onBack }) => {
     const [isCameraStarting, setIsCameraStarting] = useState(false);
     const [isRecordingVideo, setIsRecordingVideo] = useState(false);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const nativeCameraInputRef = useRef<HTMLInputElement>(null);
     const videoPreviewRef = useRef<HTMLVideoElement>(null);
     const cameraStreamRef = useRef<MediaStream | null>(null);
     const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -394,6 +395,19 @@ const BookingDetail: React.FC<BookingDetailProps> = ({ bookingId, onBack }) => {
 
     const isVideoUploadType = uploadType === 'video_before' || uploadType === 'video_after';
     const isCameraCaptureMode = Boolean(showUploadModal) && uploadInputMode === 'camera';
+
+    // Live preview (getUserMedia/MediaRecorder) needs a secure context and a full browser, and
+    // iOS Safari can't record WebM. On http://, in-app webviews, or unsupported browsers fall
+    // back to the native device camera via <input capture>.
+    const canUseLiveCamera =
+        typeof navigator !== 'undefined' &&
+        !!navigator.mediaDevices?.getUserMedia &&
+        typeof window !== 'undefined' &&
+        window.isSecureContext;
+
+    const openNativeCamera = () => {
+        nativeCameraInputRef.current?.click();
+    };
 
     const resetUploadModal = () => {
         setShowUploadModal(null);
@@ -952,7 +966,12 @@ const BookingDetail: React.FC<BookingDetailProps> = ({ bookingId, onBack }) => {
                                         type="button"
                                         onClick={() => {
                                             setSelectedFile(null);
-                                            setUploadInputMode('camera');
+                                            setCameraError(null);
+                                            if (canUseLiveCamera) {
+                                                setUploadInputMode('camera');
+                                            } else {
+                                                openNativeCamera();
+                                            }
                                         }}
                                         disabled={!uploadType}
                                         className={`px-3 py-2 rounded-lg border text-sm font-medium transition ${uploadInputMode === 'camera'
@@ -964,25 +983,53 @@ const BookingDetail: React.FC<BookingDetailProps> = ({ bookingId, onBack }) => {
                                     </button>
                                 </div>
 
+                                <input
+                                    ref={nativeCameraInputRef}
+                                    type="file"
+                                    accept={isVideoUploadType ? 'video/*' : 'image/*'}
+                                    capture="environment"
+                                    className="hidden"
+                                    onChange={(e) => {
+                                        const file = e.target.files?.[0] || null;
+                                        if (file) {
+                                            setSelectedFile(file);
+                                            setUploadInputMode('upload');
+                                        }
+                                        if (nativeCameraInputRef.current) {
+                                            nativeCameraInputRef.current.value = '';
+                                        }
+                                    }}
+                                />
+
                                 {uploadInputMode === 'camera' ? (
                                     <div className="space-y-3 rounded-lg border border-gray-200 p-3">
-                                        <div className="overflow-hidden rounded-lg bg-gray-900 aspect-[4/3] flex items-center justify-center">
+                                        <div className="relative overflow-hidden rounded-lg bg-gray-900 aspect-[4/3] flex items-center justify-center">
+                                            <video
+                                                ref={videoPreviewRef}
+                                                autoPlay
+                                                playsInline
+                                                muted
+                                                className="h-full w-full object-cover"
+                                            />
                                             {cameraError ? (
-                                                <p className="px-4 text-center text-sm text-white/85">{cameraError}</p>
+                                                <div className="absolute inset-0 flex items-center justify-center bg-gray-900 px-4 text-center">
+                                                    <div className="space-y-2">
+                                                        <p className="text-sm text-white/85">{cameraError}</p>
+                                                        <button
+                                                            type="button"
+                                                            onClick={openNativeCamera}
+                                                            className="px-3 py-1.5 bg-white/15 text-white text-sm rounded-lg hover:bg-white/25 transition"
+                                                        >
+                                                            Use device camera
+                                                        </button>
+                                                    </div>
+                                                </div>
                                             ) : isCameraStarting ? (
-                                                <div className="flex items-center text-sm text-white/85">
+                                                <div className="absolute inset-0 flex items-center justify-center bg-gray-900 text-sm text-white/85">
                                                     <Loader2 className="w-4 h-4 mr-2 animate-spin" />
                                                     Starting camera...
                                                 </div>
-                                            ) : (
-                                                <video
-                                                    ref={videoPreviewRef}
-                                                    autoPlay
-                                                    playsInline
-                                                    muted
-                                                    className="h-full w-full object-cover"
-                                                />
-                                            )}
+                                            ) : null}
                                         </div>
                                         <div className="flex gap-2 flex-wrap">
                                             {isVideoUploadType ? (


### PR DESCRIPTION
- Add native device-camera fallback (<input capture>) for user, staff booking, and staff offline booking uploads so capture works on phone browsers, in-app webviews, and non-HTTPS where getUserMedia is blocked
- Keep video element always mounted with loading/error as overlay so the camera stream attaches correctly (fixes black preview + empty capture)
- Show 'Use device camera' fallback button on camera errors