### PR TITLE
fix(fe): support iOS Safari for date picker and live video capture

### DIFF
--- a/src/components/DateTimePicker.tsx
+++ b/src/components/DateTimePicker.tsx
@@ -366,10 +366,11 @@ export default function DateTimePicker() {
 
   const valueClass = 'text-base font-bold text-primary-600 truncate';
 
-  // sr-only style for the hidden native date input — keeps it accessible &
-  // showPicker()-callable while removing it from the visual flow.
-  const visuallyHiddenInputClass =
-    'absolute h-px w-px overflow-hidden whitespace-nowrap p-0 -m-px border-0';
+  // Transparent native date input overlaid across the whole cell. Tapping the
+  // cell taps the real input directly, so iOS Safari opens its native date
+  // picker reliably (showPicker() alone is a no-op on a hidden input in iOS).
+  const dateInputOverlayClass =
+    'absolute inset-0 w-full h-full opacity-0 cursor-pointer appearance-none m-0 p-0 border-0 bg-transparent';
 
   return (
     <div>
@@ -402,7 +403,7 @@ export default function DateTimePicker() {
           </button>
 
           {/* Pickup Date */}
-          <div className={cellClass} onClick={() => openPicker(pickupDateRef)}>
+          <div className={`${cellClass} relative`} onClick={() => openPicker(pickupDateRef)}>
             <span className={`${valueClass} flex-1`}>{formatDateDDMMYYYY(pickupDate)}</span>
             <Calendar className={iconClass} />
             <input
@@ -411,9 +412,10 @@ export default function DateTimePicker() {
               type="date"
               value={pickupDate}
               onChange={(e) => handlePickupDateChange(e.target.value)}
+              onClick={() => openPicker(pickupDateRef)}
               min={minBookableDate}
               aria-label="Pickup date"
-              className={visuallyHiddenInputClass}
+              className={dateInputOverlayClass}
             />
           </div>
 
@@ -430,7 +432,7 @@ export default function DateTimePicker() {
           </div>
 
           {/* Return Date */}
-          <div className={cellClass} onClick={() => openPicker(returnDateRef)}>
+          <div className={`${cellClass} relative`} onClick={() => openPicker(returnDateRef)}>
             <span className={`${valueClass} flex-1`}>{formatDateDDMMYYYY(returnDate)}</span>
             <Calendar className={iconClass} />
             <input
@@ -439,9 +441,10 @@ export default function DateTimePicker() {
               type="date"
               value={returnDate}
               onChange={(e) => setReturnDate(e.target.value)}
+              onClick={() => openPicker(returnDateRef)}
               min={pickupDate || minBookableDate}
               aria-label="Return date"
-              className={visuallyHiddenInputClass}
+              className={dateInputOverlayClass}
             />
           </div>
 

--- a/src/pages/staff/StaffBookingsPage.tsx
+++ b/src/pages/staff/StaffBookingsPage.tsx
@@ -575,10 +575,20 @@ const BookingDetail: React.FC<BookingDetailProps> = ({ bookingId, onBack }) => {
 
         try {
             recordedChunksRef.current = [];
-            const preferredMimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp8,opus')
-                ? 'video/webm;codecs=vp8,opus'
-                : 'video/webm';
-            const recorder = new MediaRecorder(cameraStreamRef.current, { mimeType: preferredMimeType });
+            // Safari's MediaRecorder only supports MP4, not WebM. Pick the first
+            // format the browser actually supports so recording works everywhere.
+            const candidateMimeTypes = [
+                'video/webm;codecs=vp8,opus',
+                'video/webm',
+                'video/mp4;codecs=h264,aac',
+                'video/mp4',
+            ];
+            const supportedMimeType = candidateMimeTypes.find((type) =>
+                MediaRecorder.isTypeSupported(type)
+            );
+            const recorder = supportedMimeType
+                ? new MediaRecorder(cameraStreamRef.current, { mimeType: supportedMimeType })
+                : new MediaRecorder(cameraStreamRef.current);
 
             recorder.ondataavailable = (event) => {
                 if (event.data.size > 0) {
@@ -587,9 +597,11 @@ const BookingDetail: React.FC<BookingDetailProps> = ({ bookingId, onBack }) => {
             };
 
             recorder.onstop = () => {
-                const blob = new Blob(recordedChunksRef.current, { type: recorder.mimeType || 'video/webm' });
-                const file = new File([blob], `${uploadType || 'capture'}-${Date.now()}.webm`, {
-                    type: blob.type || 'video/webm',
+                const recordedType = recorder.mimeType || supportedMimeType || 'video/webm';
+                const blob = new Blob(recordedChunksRef.current, { type: recordedType });
+                const fileExtension = recordedType.includes('mp4') ? 'mp4' : 'webm';
+                const file = new File([blob], `${uploadType || 'capture'}-${Date.now()}.${fileExtension}`, {
+                    type: blob.type || recordedType,
                 });
 
                 setSelectedFile(file);


### PR DESCRIPTION
- DateTimePicker: overlay native date input across the cell so iOS Safari opens the date picker on direct tap (showPicker() was a no-op on the hidden input). Chrome/Android behavior unchanged.
- StaffBookingsPage: probe supported MediaRecorder mimeTypes and fall back to MP4 on Safari (which can't record WebM); derive file extension from the recorded type so live video capture works across browsers.